### PR TITLE
Load current user from cookie and scope actions based on current user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'webpacker', '~> 4.x'
 
 group :development, :test do
   gem 'capybara'
+  gem 'factory_bot_rails'
   gem 'pry'
   gem 'rspec'
   gem 'rspec-rails'
@@ -38,5 +39,6 @@ end
 group :test do
   gem 'database_cleaner'
 end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,11 @@ GEM
       activemodel
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     ffi (1.11.1)
     ffi (1.11.1-x64-mingw32)
     foreman (0.85.0)
@@ -259,6 +264,7 @@ DEPENDENCIES
   clearance
   database_cleaner
   dotenv-rails
+  factory_bot_rails
   foreman
   haml
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,9 @@
+class Api::BaseController < ApplicationController
+  before_action :require_login
+
+  private
+
+  def deny_access(_)
+    head :unauthorized
+  end
+end

--- a/app/controllers/api/current_users_controller.rb
+++ b/app/controllers/api/current_users_controller.rb
@@ -1,0 +1,7 @@
+class Api::CurrentUsersController < Api::BaseController
+  skip_before_action :require_login
+
+  def show
+    render json: current_user
+  end
+end

--- a/app/controllers/api/plants_controller.rb
+++ b/app/controllers/api/plants_controller.rb
@@ -1,10 +1,10 @@
-class Api::PlantsController < ApplicationController
+class Api::PlantsController < Api::BaseController
   def index
-    render json: Plant.includes(:last_watering)
+    render json: current_user.plants.includes(:last_watering)
   end
 
   def create
-    render json: Plant.create(plant_params.merge(user: User.first))
+    render json: current_user.plants.create(plant_params)
   end
 
   private

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,4 +1,6 @@
-class Api::SessionsController < ApplicationController
+class Api::SessionsController < Api::BaseController
+  skip_before_action :require_login, only: :create
+
   def create
     user = User.authenticate(user_params[:email], user_params[:password])
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,4 +1,6 @@
-class Api::UsersController < ApplicationController
+class Api::UsersController < Api::BaseController
+  skip_before_action :require_login
+
   def create
     user = User.new(user_params)
 

--- a/app/controllers/api/waterings_controller.rb
+++ b/app/controllers/api/waterings_controller.rb
@@ -1,11 +1,10 @@
-class Api::WateringsController < ApplicationController
+class Api::WateringsController < Api::BaseController
   def create
-    @plant = Plant.find(params[:plant_id])
-    if @plant.waterings.create
-      render json: @plant, status: :ok
+    plant = current_user.plants.find(params[:plant_id])
+    if plant.waterings.create
+      render json: plant, status: :created
     else
       head :bad_request
     end
   end
 end
-

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -42,7 +42,7 @@ init flags url key =
             , currentUser = Nothing
             }
     in
-    ( model, Cmd.none )
+    ( model, User.getCurrentUser ReceivedCurrentUserResponse )
         |> loadCurrentPage
 
 
@@ -60,6 +60,7 @@ type Msg
     | SignInMsg SignIn.Msg
     | UserClickedSignOutButton
     | ReceivedUserSignOutResponse (Result Http.Error ())
+    | ReceivedCurrentUserResponse (Result Http.Error User)
 
 
 type Page
@@ -98,8 +99,14 @@ update msg model =
         ( ReceivedUserSignOutResponse (Ok _), _ ) ->
             ( { model | currentUser = Nothing }, Nav.pushUrl model.key Routes.signInPath )
 
-        ( ReceivedUserSignOutResponse (Err error), _ ) ->
+        ( ReceivedUserSignOutResponse (Err _), _ ) ->
             ( model, Cmd.none )
+
+        ( ReceivedCurrentUserResponse (Ok user), _ ) ->
+            ( { model | currentUser = Just user }, Nav.pushUrl model.key Routes.plantsPath )
+
+        ( ReceivedCurrentUserResponse (Err error), _ ) ->
+            ( { model | currentUser = Nothing }, Cmd.none )
 
         ( PlantListMsg subMsg, PlantListPage pageModel ) ->
             let

--- a/app/elm/User.elm
+++ b/app/elm/User.elm
@@ -1,4 +1,4 @@
-module User exposing (Errors, NewUser, User, createUser, signIn, signOut, toCredentials)
+module User exposing (Errors, NewUser, User, createUser, getCurrentUser, signIn, signOut, toCredentials)
 
 import Http
 import HttpBuilder
@@ -76,6 +76,17 @@ signOut msg =
     in
     HttpBuilder.delete url
         |> HttpBuilder.withExpect (Http.expectWhatever msg)
+        |> HttpBuilder.request
+
+
+getCurrentUser : (Result Http.Error User -> msg) -> Cmd msg
+getCurrentUser msg =
+    let
+        url =
+            "/api/current_user"
+    in
+    HttpBuilder.get url
+        |> HttpBuilder.withExpect (Http.expectJson msg userDecoder)
         |> HttpBuilder.request
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
     resources :plants, only: [:create, :index] do
       resources :waterings, only: :create
     end
-    resources :users, only: :create
+    resources :users, only: [:create]
+    resource :current_user, only: :show
     resources :sessions, only: :create
     delete "/sign_out" => "sessions#destroy", as: "sign_out"
   end

--- a/spec/factories/plant_factory.rb
+++ b/spec/factories/plant_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :plant do
+    sequence(:name) { |n| "Plant #{n}" }
+    user
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :user do
+    first_name { 'Uncle' }
+    sequence(:last_name) { |n| "Tony #{n}" }
+    sequence(:email) { |n| "uncletony#{n}@example.com" }
+    password { 'password' }
+
+    trait :with_plants do
+      transient do
+        number { 3 }
+      end
+
+      after :create do |user, evaluator|
+        evaluator.number.times { create(:plant, user: user) }
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,8 @@ require 'database_cleaner'
 require 'rspec/rails'
 require 'spec_helper'
 
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |file| require file }
+
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 
 begin
@@ -20,6 +22,10 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+  config.include FactoryBot::Syntax::Methods
+
+  config.include ApiRequestHelpers
+  config.include JsonHelpers
 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction

--- a/spec/requests/current_user_requests_spec.rb
+++ b/spec/requests/current_user_requests_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe 'Current user requests', type: :request do
+  describe 'GET /api/current_user' do
+    context 'when a user is logged in' do
+      it 'returns the user' do
+        user = create(:user)
+        api_sign_in(user)
+
+        get api_current_user_path
+
+        user_response = response_json
+
+        expect(user_response[:id]).to eq user.id
+        expect(user_response[:first_name]).to eq user.first_name
+        expect(user_response[:last_name]).to eq user.last_name
+        expect(user_response[:email]).to eq user.email
+        expect(user_response[:remember_token]).to eq user.remember_token
+      end
+    end
+
+    context 'when a user is not logged in' do
+      it 'returns an empty JSON response' do
+        create(:user)
+
+        get api_current_user_path
+
+        user_response = response_json
+
+        expect(user_response).to be nil
+      end
+    end
+  end
+end

--- a/spec/requests/plant_requests_spec.rb
+++ b/spec/requests/plant_requests_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe 'Plant requests', type: :request do
+  describe 'get /api/plants' do
+    context 'when a user is signed in' do
+      context 'and the user has plants' do
+        it 'returns a list of the users plants' do
+          user = create(:user, :with_plants, number: 3)
+          other_plants = create_list(:plant, 3)
+          api_sign_in(user)
+
+          get api_plants_path
+
+          result = response_json
+          returned_ids = result.collect { |result| result[:id] }
+
+          expect(returned_ids.size).to eq 3
+          expect(returned_ids).to match_array user.plants.pluck(:id)
+        end
+      end
+
+      context 'and the user does not have plants' do
+        it 'returns an empty list' do
+          user = create(:user)
+          other_plants = create_list(:plant, 3)
+          api_sign_in(user)
+
+          get api_plants_path
+
+          result = response_json
+          expect(result.size).to eq 0
+        end
+      end
+    end
+
+    context 'when no user is signed in' do
+      it 'returns a 401 - Unauthorized' do
+        get '/api/plants'
+        expect(response.code).to eq '401'
+      end
+    end
+  end
+end

--- a/spec/requests/session_requests_spec.rb
+++ b/spec/requests/session_requests_spec.rb
@@ -3,30 +3,28 @@ RSpec.describe 'Session requests', type: :request do
     context 'with the required fields' do
       context 'that match an existing user' do
         it 'returns the user and status 200' do
-          user_params = { id: 100, first_name: 'Uncle', last_name: 'Tony', email: 'uncle@tony.com', password: 'password' }
-          User.create(user_params)
+          user = create(:user)
 
-          session_params = { user: { email: user_params[:email], password: user_params[:password] } }
-          post '/api/sessions', params: session_params
+          session_params = { user: { email: user.email, password: user.password } }
+          post api_sessions_path, params: session_params
 
-          user_response = JSON.parse(response.body)
+          user_response = response_json
 
-          expect(user_response['id']).to eq user_params[:id]
-          expect(user_response['first_name']).to eq user_params[:first_name]
-          expect(user_response['last_name']).to eq user_params[:last_name]
-          expect(user_response['email']).to eq user_params[:email]
-          expect(user_response['remember_token']).to be
+          expect(user_response[:id]).to eq user.id
+          expect(user_response[:first_name]).to eq user.first_name
+          expect(user_response[:last_name]).to eq user.last_name
+          expect(user_response[:email]).to eq user.email
+          expect(user_response[:remember_token]).to be
           expect(response.code).to eq '200'
         end
       end
 
       context 'that don\'t match an existing user' do
         it 'returns a 401' do
-          user_params = { first_name: 'Uncle', last_name: 'Tony', email: 'uncle@tony.com', password: 'password' }
-          User.create(user_params)
+          create(:user, email: 'realemail@example.come', password: 'realpassword')
 
           session_params = { user: { email: 'somethingelse@email.com', password: 'fake' } }
-          post '/api/sessions', params: session_params
+          post api_sessions_path, params: session_params
 
           expect(response.code).to eq '401'
         end
@@ -35,15 +33,12 @@ RSpec.describe 'Session requests', type: :request do
 
     describe 'DELETE api/sign_out' do
       it 'resets the users remember_token and returns a 200' do
-        user_params = { id: 100, first_name: 'Uncle', last_name: 'Tony', email: 'uncle@tony.com', password: 'password' }
-        user = User.create(user_params)
+        user = create(:user)
+        api_sign_in(user)
 
-        session_params = { user: { email: user_params[:email], password: user_params[:password] } }
-        post '/api/sessions', params: session_params
+        remember_token = user.remember_token
 
-        remember_token = user.reload.remember_token
-
-        delete '/api/sign_out'
+        delete api_sign_out_path
         expect(user.reload.remember_token).to_not eq remember_token
       end
     end

--- a/spec/requests/user_requests_spec.rb
+++ b/spec/requests/user_requests_spec.rb
@@ -3,15 +3,15 @@ RSpec.describe 'User requests', type: :request do
     context 'with the required fields' do
       it 'returns the created user' do
         user_params = { user: { first_name: 'Uncle', last_name: 'Tony', email: 'uncle@tony.com', password: 'password'} }
-        post '/api/users', params: user_params
+        post api_users_path, params: user_params
 
-        user_response = JSON.parse(response.body)
+        user_response = response_json
 
-        expect(user_response['id']).to be
-        expect(user_response['first_name']).to eq 'Uncle'
-        expect(user_response['last_name']).to eq 'Tony'
-        expect(user_response['email']).to eq 'uncle@tony.com'
-        expect(user_response['remember_token']).to be
+        expect(user_response[:id]).to be
+        expect(user_response[:first_name]).to eq 'Uncle'
+        expect(user_response[:last_name]).to eq 'Tony'
+        expect(user_response[:email]).to eq 'uncle@tony.com'
+        expect(user_response[:remember_token]).to be
       end
     end
   end

--- a/spec/requests/watering_requests_spec.rb
+++ b/spec/requests/watering_requests_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe 'Watering request', type: :request do
+  describe 'POST plants/:id/waterings' do
+    context 'when a user is signed in' do
+      it 'creates a watering for the given plant' do
+        plant = create(:plant, name: 'Planty')
+        api_sign_in(plant.user)
+
+        post api_plant_waterings_path(plant)
+
+        result = response_json
+
+        expect(plant.waterings.count).to eq 1
+        expect(result[:name]).to eq 'Planty'
+        expect(response.code).to eq '201'
+      end
+    end
+
+    context 'when a user is not signed in' do
+      it 'returns a 401 - Unauthorized' do
+        plant = create(:plant)
+
+        post api_plant_waterings_path(plant)
+
+        expect(response.code).to eq '401'
+      end
+    end
+  end
+end

--- a/spec/support/api_request_helpers.rb
+++ b/spec/support/api_request_helpers.rb
@@ -1,0 +1,5 @@
+module ApiRequestHelpers
+  def api_sign_in(user)
+    cookies['remember_token'] = user.remember_token
+  end
+end

--- a/spec/support/json_helpers.rb
+++ b/spec/support/json_helpers.rb
@@ -1,0 +1,6 @@
+module JsonHelpers
+  def response_json
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end
+


### PR DESCRIPTION
On the elm side, the application now tries to load a user from the
back-end based on the remember_token cookie present. If the cookie is
not present, then the app is initialized in the signed out state.

On the rails side, a new `Api::BaseController` was introduced that all
other API controllers inherit from. This controller provides a
before_action that requires a logged in user for all actions by default.

A new `Api::CurrentUsers` controller was added to provide the front-end
with the current user.

The `Api::PlantsController` and `Api::WateringsController` now scope
queries to the current user.

Finally, the requests specs were fleshed out and cleaned up with
some helper functions and factories.