### PR TITLE
Show last watering time as "# days ago" string

### DIFF
--- a/app/elm/DateAndTime.elm
+++ b/app/elm/DateAndTime.elm
@@ -1,0 +1,145 @@
+module DateAndTime exposing (distanceInDays, monthDayYearTime, secondsToPosix)
+
+import Time exposing (..)
+
+
+
+-- CONSTANTS
+
+
+millisPerDay : Int
+millisPerDay =
+    86400000
+
+
+
+-- STRING HELPERS
+
+
+monthDayYearTime : Posix -> Time.Zone -> String
+monthDayYearTime posix zone =
+    (englishMonthName <| Time.toMonth zone posix)
+        ++ " "
+        ++ (String.fromInt <| Time.toDay zone posix)
+        ++ ", "
+        ++ (String.fromInt <| Time.toYear zone posix)
+        ++ " at "
+        ++ (String.fromInt <| Time.toHour zone posix)
+        ++ ":"
+        ++ (String.padLeft 2 '0' <| String.fromInt <| Time.toMinute zone posix)
+        ++ ":"
+        ++ (String.padLeft 2 '0' <| String.fromInt <| Time.toSecond zone posix)
+
+
+distanceInDays : Time.Posix -> Time.Posix -> String
+distanceInDays currentPosix inputPosix =
+    let
+        durationInMillis =
+            findElapsedDuration currentPosix inputPosix
+    in
+    if withinTheDay durationInMillis then
+        "Today"
+
+    else if durationInMillis > 0 then
+        daysAgoString <| millisToDays durationInMillis
+
+    else
+        daysFromCurrentString <| millisToDays durationInMillis
+
+
+daysAgoString : Int -> String
+daysAgoString duration =
+    String.fromInt duration ++ " days ago"
+
+
+daysFromCurrentString : Int -> String
+daysFromCurrentString duration =
+    String.fromInt duration ++ " days from now"
+
+
+
+-- CONVERSIONS
+
+
+secondsToPosix : Int -> Posix
+secondsToPosix seconds =
+    millisToPosix (seconds * 1000)
+
+
+millisToDays : Int -> Int
+millisToDays duration =
+    let
+        durationFloat =
+            toFloat duration
+
+        millisFloat =
+            toFloat millisPerDay
+    in
+    (durationFloat / millisFloat)
+        |> ceiling
+        |> abs
+
+
+englishMonthName : Time.Month -> String
+englishMonthName month =
+    case month of
+        Time.Jan ->
+            "January"
+
+        Time.Feb ->
+            "February"
+
+        Time.Mar ->
+            "March"
+
+        Time.Apr ->
+            "April"
+
+        Time.May ->
+            "May"
+
+        Time.Jun ->
+            "June"
+
+        Time.Jul ->
+            "July"
+
+        Time.Aug ->
+            "August"
+
+        Time.Sep ->
+            "September"
+
+        Time.Oct ->
+            "October"
+
+        Time.Nov ->
+            "November"
+
+        Time.Dec ->
+            "December"
+
+
+
+-- CALCULATIONS
+
+
+withinTheDay : Int -> Bool
+withinTheDay duration =
+    let
+        absoluteDuration =
+            abs duration
+    in
+    absoluteDuration <= millisPerDay && absoluteDuration >= 0
+
+
+findElapsedDuration : Time.Posix -> Time.Posix -> Int
+findElapsedDuration currentPosix inputPosix =
+    let
+        currentTime =
+            Time.posixToMillis currentPosix
+
+        inputTime =
+            Time.posixToMillis inputPosix
+    in
+    currentTime - inputTime

--- a/app/elm/Plant.elm
+++ b/app/elm/Plant.elm
@@ -1,16 +1,19 @@
 module Plant exposing (Plant, createPlant, getPlants, plantDecoder, plantListDecoder, toNewPlant, waterPlant)
 
+import DateAndTime
 import Http
 import HttpBuilder
 import Json.Decode exposing (Decoder, int, string, succeed)
 import Json.Decode.Pipeline exposing (optional, required)
 import Json.Encode as Encode
+import Time exposing (Posix)
 
 
 type alias Plant =
     { id : Int
     , name : String
     , lastWateringDate : String
+    , lastWateredAt : Posix
     }
 
 
@@ -94,3 +97,14 @@ plantDecoder =
         |> required "id" int
         |> required "name" string
         |> optional "last_watering_date" string "Not Yet Watered"
+        |> optional "last_watered_at" posixDecoder (Time.millisToPosix 0)
+
+
+posixDecoder : Decoder Posix
+posixDecoder =
+    Json.Decode.andThen timeHelper int
+
+
+timeHelper : Int -> Decoder Posix
+timeHelper value =
+    succeed <| DateAndTime.secondsToPosix value

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -13,6 +13,10 @@ class Plant < ApplicationRecord
   validates :check_frequency_scalar, presence: true, numericality: true
   validates :check_frequency_unit, presence: true, inclusion: FREQUENCY_UNITS
 
+  def last_watered_at
+    last_watering&.happened_at
+  end
+
   def last_watering_date
     last_watering&.happened_at_date
   end

--- a/app/serializers/plant_serializer.rb
+++ b/app/serializers/plant_serializer.rb
@@ -1,3 +1,7 @@
 class PlantSerializer < ActiveModel::Serializer
-  attributes :id, :name, :last_watering_date, :next_check_date
+  attributes :id, :name, :last_watered_at, :next_check_date
+
+  def last_watered_at
+    object.last_watered_at.to_i
+  end
 end

--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "lukewestby/elm-http-builder": "7.0.0",
             "rtfeldman/elm-validate": "4.0.1"
@@ -20,7 +21,6 @@
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },


### PR DESCRIPTION
This commit changes the way the last watering date for each plant is
displayed in the plant list. Previously the date with DD/MM/YYYY format
was shown. Now the back-end passes last watering date as Posix value to
front end where conversions and formatting are done.

This commit also introduces a new DateAndTime module to the elm app.