### PR TITLE
Create plant care frequency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development, :test do
   gem 'pry'
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     tzinfo-data (1.2019.2)
@@ -272,6 +273,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/controllers/api/plant_care_events_controller.rb
+++ b/app/controllers/api/plant_care_events_controller.rb
@@ -1,7 +1,7 @@
-class Api::WateringsController < Api::BaseController
+class Api::PlantCareEventsController < Api::BaseController
   def create
     plant = current_user.plants.find(params[:plant_id])
-    if plant.waterings.create
+    if plant.plant_care_events.create(kind: params[:kind])
       render json: plant, status: :created
     else
       head :bad_request

--- a/app/controllers/api/plants_controller.rb
+++ b/app/controllers/api/plants_controller.rb
@@ -1,15 +1,20 @@
 class Api::PlantsController < Api::BaseController
   def index
-    render json: current_user.plants.includes(:last_watering)
+    render json: current_user.plants.includes(:last_watering, :last_check)
   end
 
   def create
-    render json: current_user.plants.create(plant_params)
+    plant = current_user.plants.create(plant_params)
+    if plant.errors.empty?
+      render json: plant, status: :created
+    else
+      render json: plant.errors, status: :unprocessable_entity
+    end
   end
 
   private
 
   def plant_params
-    params.require(:plant).permit(:name)
+    params.require(:plant).permit(:name, :check_frequency_unit, :check_frequency_scalar)
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
+  include ActionView::Helpers::TranslationHelper
   self.abstract_class = true
 end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -1,11 +1,38 @@
 class Plant < ApplicationRecord
-  belongs_to :user
-  has_many :waterings, -> { order(watered_at: :desc) }
-  has_one :last_watering, -> { order(watered_at: :desc) }, class_name: 'Watering'
+  FREQUENCY_UNITS = %w[day week].freeze
 
-  validates :user, presence: true
+  belongs_to :user
+  has_many :plant_care_events
+  has_one :last_care_event, class_name: 'PlantCareEvent'
+  has_one :last_watering, -> { watering }, class_name: 'PlantCareEvent'
+  has_one :last_check, -> { check }, class_name: 'PlantCareEvent'
+  has_many :waterings, -> { watering }, class_name: 'PlantCareEvent'
+  has_many :checks, -> { check }, class_name: 'PlantCareEvent'
+
+  validates :user, :name, presence: true
+  validates :check_frequency_scalar, presence: true, numericality: true
+  validates :check_frequency_unit, presence: true, inclusion: FREQUENCY_UNITS
 
   def last_watering_date
-    last_watering&.watered_at_date
+    last_watering&.happened_at_date
+  end
+
+  def next_check_date
+    l(next_check_time, format: :month_day_year)
+  end
+
+  def check_frequency
+    check_frequency_scalar.public_send(check_frequency_unit)
+  end
+
+  private
+
+  def recent_care_event
+    last_care_event || NullCareEvent.new(self)
+  end
+
+  def next_check_time
+    time_from_care_event = recent_care_event.happened_at + check_frequency
+    [time_from_care_event, Time.current].max
   end
 end

--- a/app/models/plant_care_event.rb
+++ b/app/models/plant_care_event.rb
@@ -1,0 +1,17 @@
+class PlantCareEvent < ApplicationRecord
+  belongs_to :plant
+
+  KINDS = %w[watering check].freeze
+
+  validates :kind, inclusion: KINDS
+  validates :plant, presence: true
+
+  default_scope -> { order(happened_at: :desc) }
+
+  scope :watering, -> { where kind: 'watering' }
+  scope :check, -> { where kind: 'check'}
+
+  def happened_at_date
+    l(happened_at, format: :month_day_year)
+  end
+end

--- a/app/models/watering.rb
+++ b/app/models/watering.rb
@@ -1,7 +1,0 @@
-class Watering < ApplicationRecord
-  belongs_to :plant
-
-  def watered_at_date
-    watered_at.strftime("%m/%d/%Y")
-  end
-end

--- a/app/serializers/plant_serializer.rb
+++ b/app/serializers/plant_serializer.rb
@@ -1,3 +1,3 @@
 class PlantSerializer < ActiveModel::Serializer
-  attributes :id, :name, :last_watering_date
+  attributes :id, :name, :last_watering_date, :next_check_date
 end

--- a/app/services/null_care_event.rb
+++ b/app/services/null_care_event.rb
@@ -1,0 +1,15 @@
+class NullCareEvent
+  attr_accessor :plant
+
+  def initialize(plant)
+    @plant = plant
+  end
+
+  def happened_at
+    Time.at(0)
+  end
+
+  def happened_at_date
+    I18n.l(happened_at, format: :month_day_year)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,4 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  time:
+    formats:
+      month_day_year: '%m/%d/%Y'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :plants, only: [:create, :index] do
-      resources :waterings, only: :create
+      resources :plant_care_events, only: :create
     end
     resources :users, only: [:create]
     resource :current_user, only: :show

--- a/db/migrate/20190624153510_create_waterings.rb
+++ b/db/migrate/20190624153510_create_waterings.rb
@@ -1,9 +1,13 @@
 class CreateWaterings < ActiveRecord::Migration[5.2]
-  def change
+  def up
     create_table :waterings do |t|
       t.references :plant, index: true, null: false
       t.timestamp :watered_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
       t.timestamps
     end
+  end
+
+  def down
+    drop_table :waterings
   end
 end

--- a/db/migrate/20190731191936_add_watering_frequency_to_plants.rb
+++ b/db/migrate/20190731191936_add_watering_frequency_to_plants.rb
@@ -1,0 +1,6 @@
+class AddWateringFrequencyToPlants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :plants, :watering_frequency_scalar, :integer, null: false
+    add_column :plants, :watering_frequency_unit, :string, null: false
+  end
+end

--- a/db/migrate/20190802181509_create_checks.rb
+++ b/db/migrate/20190802181509_create_checks.rb
@@ -1,0 +1,13 @@
+class CreateChecks < ActiveRecord::Migration[5.2]
+  def up
+    create_table :checks do |t|
+      t.timestamp :checked_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.references :plant, index: true, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :checks
+  end
+end

--- a/db/migrate/20190806233735_rename_watering_frequency_columns.rb
+++ b/db/migrate/20190806233735_rename_watering_frequency_columns.rb
@@ -1,0 +1,8 @@
+class RenameWateringFrequencyColumns < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :plants, :watering_frequency_scalar, :check_frequency_scalar
+    rename_column :plants, :watering_frequency_unit, :check_frequency_unit
+    change_column_default :plants, :check_frequency_scalar, from: 1, to: 3
+    change_column_default :plants, :check_frequency_unit, from: 'weeks', to: 'days'
+  end
+end

--- a/db/migrate/20190806233742_create_plant_care_events.rb
+++ b/db/migrate/20190806233742_create_plant_care_events.rb
@@ -1,0 +1,43 @@
+require './db/migrate/20190624153510_create_waterings.rb'
+require './db/migrate/20190802181509_create_checks.rb'
+
+class CreatePlantCareEvents < ActiveRecord::Migration[5.2]
+  class Watering < ApplicationRecord; end
+  class Check < ApplicationRecord; end
+  class PlantCareEvent < ApplicationRecord; end
+
+  def up
+    create_table :plant_care_events do |t|
+      t.references :plant, index: true, foreign_key: true
+      t.timestamp :happened_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.string :kind, null: false
+      t.timestamps
+    end
+
+    Watering.find_each do |watering|
+      PlantCareEvent.create!(happened_at: watering.watered_at, plant_id: watering.plant_id, kind: 'watering')
+    end
+
+    Check.find_each do |check|
+      PlantCareEvent.create!(happened_at: check.checked_at, plant_id: check.plant_id, kind: 'check')
+    end
+
+    drop_table :waterings
+    drop_table :checks
+  end
+
+  def down
+    CreateWaterings.new.up
+    CreateChecks.new.up
+
+    PlantCareEvent.find_each do |event|
+      if event.kind == 'watering'
+        Watering.create!(plant_id: event.plant_id, watered_at: event.happened_at)
+      else
+        Check.create!(plant_id: event.plant_id, checked_at: event.happened_at)
+      end
+    end
+
+    drop_table :plant_care_events
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_143848) do
+ActiveRecord::Schema.define(version: 2019_08_06_233742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "plant_care_events", force: :cascade do |t|
+    t.bigint "plant_id"
+    t.datetime "happened_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "kind", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plant_id"], name: "index_plant_care_events_on_plant_id"
+  end
 
   create_table "plants", force: :cascade do |t|
     t.string "name"
     t.string "botanical_name"
     t.bigint "user_id"
+    t.integer "check_frequency_scalar", default: 3, null: false
+    t.string "check_frequency_unit", default: "days", null: false
     t.index ["user_id"], name: "index_plants_on_user_id"
   end
 
@@ -35,13 +46,6 @@ ActiveRecord::Schema.define(version: 2019_07_17_143848) do
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 
-  create_table "waterings", force: :cascade do |t|
-    t.bigint "plant_id", null: false
-    t.datetime "watered_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["plant_id"], name: "index_waterings_on_plant_id"
-  end
-
+  add_foreign_key "plant_care_events", "plants"
   add_foreign_key "plants", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,19 @@ user = User.create!(
   password: "password"
 )
 
-12.times { |i| Plant.create!(user: user, name: "Plant #{i}", botanical_name: "Newus Plantus #{i}") }
+12.times do |i|
+  Plant.create!(
+    user: user,
+    name: "Plant #{i}",
+    botanical_name: "Newus Plantus #{i}",
+    check_frequency_scalar: 1,
+    check_frequency_unit: 'week'
+  )
+end
+
+Plant.find_each do |plant|
+  plant.plant_care_events.create!(
+    kind: 'watering',
+    happened_at: Array(1..9).sample.days.ago
+  )
+end

--- a/spec/factories/plant_care_event_factory.rb
+++ b/spec/factories/plant_care_event_factory.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :plant_care_event do
+    happened_at { Time.current }
+    plant
+
+    factory :watering do
+      kind { 'watering' }
+    end
+
+    factory :check do
+      kind { 'check' }
+    end
+  end
+end

--- a/spec/factories/plant_factory.rb
+++ b/spec/factories/plant_factory.rb
@@ -2,5 +2,22 @@ FactoryBot.define do
   factory :plant do
     sequence(:name) { |n| "Plant #{n}" }
     user
+    check_frequency_scalar { 1 }
+    check_frequency_unit { 'day' }
+
+    trait :with_weekly_check do
+      check_frequency_scalar { 1 }
+      check_frequency_unit { 'week' }
+    end
+
+    trait :with_waterings do
+      transient do
+        number { 2 }
+      end
+
+      after :create do |plant, evaluator|
+        create_list(:watering, number, plant: plant)
+      end
+    end
   end
 end

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Plant do
+  describe '#next_watering' do
+    around(:each) do |example|
+      Timecop.freeze do
+        example.run
+      end
+    end
+
+    context 'when the plant has at least one watering' do
+      context 'and no checks' do
+        it 'returns the last watering\'s date plus the check frequency' do
+          watering_date = 1.day.ago
+          expected_next_check = watering_date + 1.week
+
+          plant = create(:plant, :with_weekly_check)
+          create(:watering, plant: plant, happened_at: watering_date)
+
+          expect(plant.next_check_date).to eq expected_next_check.strftime('%m/%d/%Y')
+        end
+      end
+
+      context 'and a check that is less recent than the watering' do
+        it 'returns the last watering\'s date plus the check frequency' do
+          watering_date = 1.day.ago
+          check_date = 3.day.ago
+          expected_next_check = watering_date + 1.week
+
+          plant = create(:plant, :with_weekly_check)
+          create(:watering, plant: plant, happened_at: watering_date)
+          create(:check, plant: plant, happened_at: check_date)
+
+          expect(plant.next_check_date).to eq expected_next_check.strftime('%m/%d/%Y')
+        end
+      end
+
+      context 'and a check that is more recent than the watering' do
+        it 'returns the check\'s date plus the check frequency' do
+          watering_date = 3.day.ago
+          check_date = 1.day.ago
+          expected_next_check = check_date + 1.week
+
+          plant = create(:plant, :with_weekly_check)
+          create(:watering, plant: plant, happened_at: watering_date)
+          create(:check, plant: plant, happened_at: check_date)
+
+          expect(plant.next_check_date).to eq expected_next_check.strftime('%m/%d/%Y')
+        end
+      end
+    end
+
+    context 'when the plant has at least one check and no waterings' do
+      it 'returns the check\'s date plus the check frequency' do
+        check_date = 1.day.ago
+        expected_next_check = check_date + 1.week
+
+        plant = create(:plant, :with_weekly_check)
+        create(:check, plant: plant, happened_at: check_date)
+
+        expect(plant.next_check_date).to eq expected_next_check.strftime('%m/%d/%Y')
+      end
+    end
+
+    context 'when the plant does not have any waterings or checks' do
+      it 'returns the current time' do
+        Timecop.freeze do
+          plant = create(:plant, :with_weekly_check)
+
+          expect(plant.next_check_date).to eq Time.current.strftime('%m/%d/%Y')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/plant_care_event_requests_spec.rb
+++ b/spec/requests/plant_care_event_requests_spec.rb
@@ -1,11 +1,11 @@
-RSpec.describe 'Watering request', type: :request do
-  describe 'POST plants/:id/waterings' do
+RSpec.describe 'Plant care event request', type: :request do
+  describe 'POST plants/:id/plant_care_events' do
     context 'when a user is signed in' do
       it 'creates a watering for the given plant' do
         plant = create(:plant, name: 'Planty')
         api_sign_in(plant.user)
 
-        post api_plant_waterings_path(plant)
+        post api_plant_plant_care_events_path(plant), params: { kind: 'watering'}
 
         result = response_json
 
@@ -19,7 +19,7 @@ RSpec.describe 'Watering request', type: :request do
       it 'returns a 401 - Unauthorized' do
         plant = create(:plant)
 
-        post api_plant_waterings_path(plant)
+        post api_plant_plant_care_events_path(plant)
 
         expect(response.code).to eq '401'
       end

--- a/spec/requests/plant_requests_spec.rb
+++ b/spec/requests/plant_requests_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Plant requests', type: :request do
-  describe 'get /api/plants' do
+  describe 'GET /api/plants' do
     context 'when a user is signed in' do
       context 'and the user has plants' do
         it 'returns a list of the users plants' do
@@ -35,6 +35,45 @@ RSpec.describe 'Plant requests', type: :request do
       it 'returns a 401 - Unauthorized' do
         get '/api/plants'
         expect(response.code).to eq '401'
+      end
+    end
+  end
+
+  describe 'POST /api/plants' do
+    context 'with valid input' do
+      it 'returns the created plant' do
+        user = create(:user)
+        plant_params = { plant:
+          { name: 'Bobby',
+            check_frequency_scalar: 1,
+            check_frequency_unit: 'week' } }
+
+        api_sign_in(user)
+        post api_plants_path, params: plant_params
+
+        result = response_json
+
+        expect(result[:name]).to eq 'Bobby'
+        expect(result[:last_watering_date]).to be nil
+        expect(result[:next_check_date]).to eq I18n.l(Time.current, format: :month_day_year)
+      end
+    end
+
+    context 'with an invalid input' do
+      it 'returns a 422 - Unprocessable Entity' do
+        user = create(:user)
+        plant_params = { plant:
+          { name: nil,
+            check_frequency_scalar: nil,
+            check_frequency_unit: nil } }
+
+        api_sign_in(user)
+        post api_plants_path, params: plant_params
+
+        result = response_json
+
+        expect(response.code).to eq '422'
+        expect(result.keys).to match_array [:name, :check_frequency_scalar, :check_frequency_unit]
       end
     end
   end


### PR DESCRIPTION
This commit adds the ability to specify how often you want to check a
given plant.

This will allow us to add some inputs to the front end so we can specify
care frequency on plant creation (e.g., 1 week, 3 days).

I also refactored the waterings/checks into a single class
`PlantCareEvent`. They seemed to overlap in functionality/data. Using
the new model, we can now calculate when the plant should be checked
next based the last time a plant was cared for (watered or checked)