### PR TITLE
Plant check-in modal front-end

### DIFF
--- a/app/elm/Pages/PlantList.elm
+++ b/app/elm/Pages/PlantList.elm
@@ -14,9 +14,10 @@ module Pages.PlantList exposing
 import DateAndTime
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick)
+import Html.Events exposing (onClick, onInput)
 import Http
 import Plant
+import Process
 import Routes exposing (newPlantPath)
 import Task
 import Time exposing (Posix)
@@ -28,22 +29,60 @@ type alias Model =
     , currentUser : User
     , currentTime : Posix
     , currentTimeZone : Time.Zone
+    , modal : Modal
+    , checkInForm : CheckInForm
     }
+
+
+type alias CheckInForm =
+    { checked : Bool
+    , watered : Bool
+    , fertilized : Bool
+    , plant : Plant.Plant
+    , notes : String
+    }
+
+
+type PlantCareEvent
+    = Watered
+    | Fertilized
+    | Checked
+    | NoEvent
 
 
 type Msg
     = NewPlants (Result Http.Error (List Plant.Plant))
-    | WaterPlant Plant.Plant
+    | UserOpenedCheckInModal Plant.Plant
+    | UserClosedModal
+    | UserSubmittedCheckIn
     | UpdatePlant (Result Http.Error Plant.Plant)
     | ReceivedCurrentTime Time.Posix
     | ReceivedTimeZone Time.Zone
+    | CheckboxSelected PlantCareEvent
+    | UserTypedCheckInNotes String
+    | ReceivedPlantCheckInResponse (Result Http.Error {})
+
+
+type Modal
+    = Modal (Html Msg)
+    | ModalClosed
 
 
 init : User -> ( Model, Cmd Msg )
 init user =
-    ( Model [] user initialTime Time.utc
+    ( initialModel user
     , Cmd.batch [ getCurrentTime, getTimeZone, getPlants ]
     )
+
+
+initialModel : User -> Model
+initialModel user =
+    Model [] user initialTime Time.utc ModalClosed initialCheckInForm
+
+
+initialCheckInForm : CheckInForm
+initialCheckInForm =
+    CheckInForm False False False Plant.emptyPlant ""
 
 
 getCurrentTime : Cmd Msg
@@ -88,14 +127,101 @@ update msg model =
             in
             ( model, Cmd.none )
 
-        WaterPlant plant ->
-            ( model, waterPlant plant )
+        UserOpenedCheckInModal plant ->
+            let
+                checkInForm =
+                    model.checkInForm
+
+                newCheckInForm =
+                    { checkInForm | plant = plant }
+            in
+            ( model, Cmd.none )
+                |> updateForm newCheckInForm
+                |> updateModal checkInModal
+
+        CheckboxSelected eventType ->
+            let
+                newCheckInForm =
+                    updateFormCheckboxes model.checkInForm eventType
+            in
+            ( model, Cmd.none )
+                |> updateForm newCheckInForm
+                |> updateModal checkInModal
+
+        UserTypedCheckInNotes notes ->
+            let
+                checkInForm =
+                    model.checkInForm
+
+                newCheckInForm =
+                    { checkInForm | notes = notes }
+            in
+            ( model, Cmd.none )
+                |> updateForm newCheckInForm
+                |> updateModal checkInModal
+
+        UserClosedModal ->
+            ( model, Cmd.none )
+                |> updateForm initialCheckInForm
+                |> closeModal
+
+        UserSubmittedCheckIn ->
+            ( model, submitPlantCheckIn model.checkInForm )
+
+        ReceivedPlantCheckInResponse (Ok response) ->
+            ( model, Cmd.none )
+                |> updateForm initialCheckInForm
+                |> closeModal
+
+        ReceivedPlantCheckInResponse (Err error) ->
+            ( model, Cmd.none )
 
         ReceivedTimeZone zone ->
             ( { model | currentTimeZone = zone }, Cmd.none )
 
         ReceivedCurrentTime time ->
             ( { model | currentTime = time }, Cmd.none )
+
+
+updateFormCheckboxes : CheckInForm -> PlantCareEvent -> CheckInForm
+updateFormCheckboxes checkInForm event =
+    case event of
+        Watered ->
+            { checkInForm
+                | watered = not checkInForm.watered
+                , checked = False
+            }
+
+        Fertilized ->
+            { checkInForm
+                | fertilized = not checkInForm.fertilized
+                , checked = False
+            }
+
+        Checked ->
+            { checkInForm
+                | checked = not checkInForm.checked
+                , watered = False
+                , fertilized = False
+            }
+
+        NoEvent ->
+            checkInForm
+
+
+updateForm : CheckInForm -> ( Model, Cmd Msg ) -> ( Model, Cmd Msg )
+updateForm form ( model, cmd ) =
+    ( { model | checkInForm = form }, cmd )
+
+
+updateModal : (CheckInForm -> Html Msg) -> ( Model, Cmd Msg ) -> ( Model, Cmd Msg )
+updateModal modal ( model, cmd ) =
+    ( { model | modal = Modal <| modal model.checkInForm }, cmd )
+
+
+closeModal : ( Model, Cmd Msg ) -> ( Model, Cmd Msg )
+closeModal ( model, cmd ) =
+    ( { model | modal = ModalClosed }, cmd )
 
 
 updatePlantsList : List Plant.Plant -> Plant.Plant -> List Plant.Plant
@@ -120,6 +246,7 @@ view model =
     div []
         [ viewPlantList model
         , a [ class "add-record-btn", href newPlantPath ] [ text "Add New Plant" ]
+        , viewModal model.modal
         ]
 
 
@@ -157,8 +284,9 @@ card currentTime plant =
                 [ li [] [ text "Botanical Name" ]
                 , li [] [ text <| distanceInDays currentTime plant.lastWateredAt ]
                 , li []
-                    [ button [ onClick (WaterPlant plant) ]
-                        [ text "Water" ]
+                    [ button
+                        [ onClick (UserOpenedCheckInModal plant) ]
+                        [ text "Check In" ]
                     ]
                 ]
             ]
@@ -186,3 +314,113 @@ getPlants =
 waterPlant : Plant.Plant -> Cmd Msg
 waterPlant plant =
     Plant.waterPlant UpdatePlant plant
+
+
+submitPlantCheckIn : CheckInForm -> Cmd Msg
+submitPlantCheckIn form =
+    Process.sleep 2000
+        |> Task.perform (\_ -> ReceivedPlantCheckInResponse (Ok fakeCheckInResponse))
+
+
+fakeCheckInResponse =
+    {}
+
+
+
+-- MODAL
+
+
+viewModal : Modal -> Html Msg
+viewModal modal =
+    case modal of
+        Modal content ->
+            content
+
+        _ ->
+            div [] []
+
+
+checkInModal : CheckInForm -> Html Msg
+checkInModal form =
+    div [ class "modal__bg" ]
+        [ div [ class "modal__container--large" ]
+            [ modalHeader <| "Check-in: " ++ form.plant.name
+            , div [ class "modal__content--large" ]
+                [ modalRow [ h2 [] [ text "Today I:" ] ]
+                , modalRow
+                    [ checkbox Watered
+                        form.watered
+                    ]
+                , modalRow
+                    [ checkbox Fertilized
+                        form.fertilized
+                    ]
+                , modalRow
+                    [ checkbox Checked
+                        form.checked
+                    ]
+                , modalRow
+                    [ label []
+                        [ text "Notes"
+                        , textarea
+                            [ onInput UserTypedCheckInNotes
+                            , style "height" "125px"
+                            ]
+                            []
+                        ]
+                    ]
+                ]
+            , modalFooter
+                [ button [ class "secondary", onClick UserClosedModal ] [ text "Cancel" ]
+                , button [ onClick UserSubmittedCheckIn ] [ text "Submit" ]
+                ]
+            ]
+        ]
+
+
+checkbox : PlantCareEvent -> Bool -> Html Msg
+checkbox eventType isChecked =
+    label
+        [ style "padding" "20px" ]
+        [ input
+            [ type_ "checkbox"
+            , checked isChecked
+            , onClick <| CheckboxSelected eventType
+            ]
+            []
+        , text (eventToString eventType)
+        ]
+
+
+eventToString : PlantCareEvent -> String
+eventToString event =
+    case event of
+        Watered ->
+            "Watered"
+
+        Fertilized ->
+            "Fertilized"
+
+        Checked ->
+            "No Action"
+
+        NoEvent ->
+            "NoEvent"
+
+
+modalHeader : String -> Html Msg
+modalHeader headerText =
+    div [ class "modal__header--default" ]
+        [ h1 [ class "modal__heading" ]
+            [ text headerText ]
+        ]
+
+
+modalFooter : List (Html a) -> Html a
+modalFooter children =
+    div [ class "modal__footer" ] children
+
+
+modalRow : List (Html a) -> Html a
+modalRow children =
+    div [ class "modal-row" ] children

--- a/app/elm/Plant.elm
+++ b/app/elm/Plant.elm
@@ -1,4 +1,13 @@
-module Plant exposing (Plant, createPlant, getPlants, plantDecoder, plantListDecoder, toNewPlant, waterPlant)
+module Plant exposing
+    ( Plant
+    , createPlant
+    , emptyPlant
+    , getPlants
+    , plantDecoder
+    , plantListDecoder
+    , toNewPlant
+    , waterPlant
+    )
 
 import DateAndTime
 import Http
@@ -22,6 +31,11 @@ type alias NewPlant =
     , checkFrequencyUnit : String
     , checkFrequencyScalar : String
     }
+
+
+emptyPlant : Plant
+emptyPlant =
+    Plant 0 "" "" (Time.millisToPosix 0)
 
 
 getPlants : (Result Http.Error (List Plant) -> msg) -> Cmd msg


### PR DESCRIPTION
This commit includes the front end portion of a new modal used for
recording plant care. Users can select what they did to a plant
(watered, fertilized, checked on) and record some notes.