### PR TITLE
Notices

### DIFF
--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -20,8 +20,8 @@ $light-gray: #ddd;
 
 $alert: #fff6bf;
 $error: #fbe3e4;
-$notice: #e5edf8;
-$success: #e6efc2;
+$notice: #e6efc2;
+$success: #e5edf8;
 
 $white: #fff;
 $plantiful-green: #dbffce;

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -7,6 +7,7 @@
   padding: 20px;
 
   box-shadow: 0 1px 4px $light-gray;
+  z-index: 1;
 }
 
 .header__item--full {

--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -104,3 +104,26 @@
   font-size: $font-size-large;
 }
 
+.notice {
+  position: relative;
+  background: $notice;
+  box-shadow: 0 1px 4px #ddd;
+  line-height: 2.5;
+  overflow: hidden;
+  text-align: center;
+  z-index: -1;
+
+  -webkit-transform: translateY(-110px);
+  -webkit-animation: slideDown 2.5s 0.5s 1 ease forwards;
+  -moz-transform: translateY(-110px);
+  -moz-animation: slideDown 2.5s 0.5s 1 ease forwards;
+}
+
+@-webkit-keyframes slideDown {
+    0%, 100% { -webkit-transform: translateY(-110px); }
+    10%, 90% { -webkit-transform: translateY(0px); }
+}
+@-moz-keyframes slideDown {
+    0%, 100% { -moz-transform: translateY(-110px); }
+    10%, 90% { -moz-transform: translateY(0px); }
+}

--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -104,26 +104,3 @@
   font-size: $font-size-large;
 }
 
-.notice {
-  position: relative;
-  background: $notice;
-  box-shadow: 0 1px 4px #ddd;
-  line-height: 2.5;
-  overflow: hidden;
-  text-align: center;
-  z-index: -1;
-
-  -webkit-transform: translateY(-110px);
-  -webkit-animation: slideDown 2.5s 0.5s 1 ease forwards;
-  -moz-transform: translateY(-110px);
-  -moz-animation: slideDown 2.5s 0.5s 1 ease forwards;
-}
-
-@-webkit-keyframes slideDown {
-    0%, 100% { -webkit-transform: translateY(-110px); }
-    10%, 90% { -webkit-transform: translateY(0px); }
-}
-@-moz-keyframes slideDown {
-    0%, 100% { -moz-transform: translateY(-110px); }
-    10%, 90% { -moz-transform: translateY(0px); }
-}

--- a/app/assets/stylesheets/components/notices.scss
+++ b/app/assets/stylesheets/components/notices.scss
@@ -1,0 +1,27 @@
+.notice {
+  position: relative;
+  box-shadow: 0 1px 4px #ddd;
+  line-height: 2.5;
+  overflow: hidden;
+  text-align: center;
+  z-index: -1;
+
+  -webkit-transform: translateY(-110px);
+  -webkit-animation: slideDown 2.5s 0.5s 1 ease forwards;
+  -moz-transform: translateY(-110px);
+  -moz-animation: slideDown 2.5s 0.5s 1 ease forwards;
+}
+
+.notice-alert { background: $alert }
+.notice-error { background: $error }
+.notice-info { background: $notice }
+.notice-success { background: $success }
+
+@-webkit-keyframes slideDown {
+    0%, 100% { -webkit-transform: translateY(-110px); }
+    10%, 90% { -webkit-transform: translateY(0px); }
+}
+@-moz-keyframes slideDown {
+    0%, 100% { -moz-transform: translateY(-110px); }
+    10%, 90% { -moz-transform: translateY(0px); }
+}

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -186,13 +186,19 @@ update msg model =
             in
             ( { model
                 | session = updatedSession
-                , notice = Notice "Signed out succesfully"
+                , notice = Notice "Signed out succesfully" Notice.NoticeSuccess
               }
             , Nav.pushUrl model.key Routes.signInPath
             )
 
         ( ReceivedUserSignOutResponse (Err _), _ ) ->
-            ( { model | notice = Notice "Something went wrong. Try again later." }, Cmd.none )
+            ( { model
+                | notice =
+                    Notice "Something went wrong. Try again later."
+                        Notice.NoticeError
+              }
+            , Cmd.none
+            )
 
         ( ReceivedCurrentUserResponse route (Ok user), _ ) ->
             let
@@ -292,7 +298,7 @@ update msg model =
                                 user.ownedGardens
                                 user.sharedGardens
                             , updatedSession
-                            , Notice "Welcome to Plantiful!"
+                            , Notice "Welcome to Plantiful!" Notice.NoticeSuccess
                             )
 
                         Nothing ->
@@ -315,12 +321,16 @@ update msg model =
                 ( loadableUser, newMenu, newNotice ) =
                     case currentUser of
                         Just user ->
+                            let
+                                noticeMessage =
+                                    "Welcome back, " ++ user.firstName
+                            in
                             ( Success user
                             , initMenu model.session
                                 model.key
                                 user.ownedGardens
                                 user.sharedGardens
-                            , Notice <| "Welcome back, " ++ user.firstName
+                            , Notice noticeMessage Notice.NoticeSuccess
                             )
 
                         Nothing ->
@@ -580,8 +590,15 @@ viewNotice notice =
         EmptyNotice ->
             text ""
 
-        Notice message ->
-            div [ class "notice" ] [ text message ]
+        Notice message noticeClass ->
+            let
+                noticeClassString =
+                    Notice.noticeClassToString noticeClass
+
+                classString =
+                    "notice " ++ noticeClassString
+            in
+            div [ class classString ] [ text message ]
 
 
 viewMenu : Menu -> Html Msg

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -25,6 +25,7 @@ import Json.Decode exposing (Decoder, string, succeed)
 import Json.Decode.Pipeline exposing (required)
 import Loadable exposing (Loadable(..))
 import Menu
+import Notice exposing (Notice(..))
 import Pages.NotAuthorized as NotAuthorized
 import Pages.PlantDetails as PlantDetails
 import Pages.PlantForm as PlantForm
@@ -51,6 +52,7 @@ type alias Model =
     , timeZone : Time.Zone
     , session : Session.Session
     , menu : Menu
+    , notice : Notice.Notice
     }
 
 
@@ -74,6 +76,7 @@ init flags url key =
             , timeZone = Time.utc
             , session = Session.Session flags.csrfToken Loading
             , menu = MenuNone
+            , notice = EmptyNotice
             }
 
         initCmds =
@@ -257,10 +260,10 @@ update msg model =
 
         ( PlantFormMsg subMsg, PlantFormPage pageModel ) ->
             let
-                ( newPageModel, newCmd ) =
+                ( newPageModel, newCmd, newNotice ) =
                     PlantForm.update subMsg pageModel model.key
             in
-            ( { model | page = PlantFormPage newPageModel }
+            ( { model | page = PlantFormPage newPageModel, notice = newNotice }
             , Cmd.map PlantFormMsg newCmd
             )
 
@@ -544,6 +547,7 @@ currentPage model =
     in
     div []
         [ nav model
+        , viewNotice model.notice
         , div [ class "main" ] [ page ]
         ]
 
@@ -558,6 +562,16 @@ nav model =
             ]
         , headerLink model
         ]
+
+
+viewNotice : Notice -> Html Msg
+viewNotice notice =
+    case notice of
+        EmptyNotice ->
+            text ""
+
+        Notice message ->
+            div [ class "notice" ] [ text message ]
 
 
 viewMenu : Menu -> Html Msg

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -314,7 +314,7 @@ update msg model =
                             )
 
                         Nothing ->
-                            ( MenuNone, session, Nothing )
+                            ( MenuNone, session, Notice.empty )
             in
             ( { model
                 | page = UserPage newPageModel
@@ -345,7 +345,7 @@ update msg model =
                             )
 
                         Nothing ->
-                            ( None, MenuNone, Nothing )
+                            ( None, MenuNone, Notice.empty )
 
                 session =
                     model.session

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -25,7 +25,7 @@ import Json.Decode exposing (Decoder, string, succeed)
 import Json.Decode.Pipeline exposing (required)
 import Loadable exposing (Loadable(..))
 import Menu
-import Notice exposing (Notice(..))
+import Notice exposing (Notice)
 import NoticeQueue exposing (NoticeQueue(..))
 import Pages.NotAuthorized as NotAuthorized
 import Pages.PlantDetails as PlantDetails
@@ -192,7 +192,7 @@ update msg model =
                     { session | currentUser = None }
 
                 newNotice =
-                    Notice "Signed out succesfully" Notice.NoticeSuccess
+                    Notice.success "Signed out succesfully"
             in
             ( { model | session = updatedSession }
             , Nav.pushUrl model.key Routes.signInPath
@@ -202,7 +202,7 @@ update msg model =
         ( ReceivedUserSignOutResponse (Err _), _ ) ->
             let
                 newNotice =
-                    Notice "Something went wrong. Try again later." Notice.NoticeError
+                    Notice.error "Something went wrong. Try again later."
             in
             ( model, Cmd.none )
                 |> updateNoticeQueue (Just newNotice)
@@ -307,10 +307,7 @@ update msg model =
                                 user.ownedGardens
                                 user.sharedGardens
                             , updatedSession
-                            , Just
-                                (Notice "Welcome to Plantiful!"
-                                    Notice.NoticeSuccess
-                                )
+                            , Just (Notice.success "Welcome to Plantiful!")
                             )
 
                         Nothing ->
@@ -341,7 +338,7 @@ update msg model =
                                 model.key
                                 user.ownedGardens
                                 user.sharedGardens
-                            , Just (Notice noticeMessage Notice.NoticeSuccess)
+                            , Just (Notice.success noticeMessage)
                             )
 
                         Nothing ->
@@ -617,25 +614,9 @@ nav model =
         ]
 
 
-viewNotice : NoticeQueue -> Html Msg
+viewNotice : NoticeQueue -> Html a
 viewNotice queue =
-    let
-        currentNotice =
-            NoticeQueue.currentNotice queue
-    in
-    case currentNotice of
-        Just (Notice message noticeClass) ->
-            let
-                noticeClassString =
-                    Notice.noticeClassToString noticeClass
-
-                classString =
-                    "notice " ++ noticeClassString
-            in
-            div [ class classString ] [ text message ]
-
-        _ ->
-            text ""
+    NoticeQueue.viewCurrentNotice queue
 
 
 viewMenu : Menu -> Html Msg

--- a/app/elm/Notice.elm
+++ b/app/elm/Notice.elm
@@ -1,0 +1,6 @@
+module Notice exposing (Notice(..))
+
+
+type Notice
+    = EmptyNotice
+    | Notice String

--- a/app/elm/Notice.elm
+++ b/app/elm/Notice.elm
@@ -1,15 +1,20 @@
-module Notice exposing (Class(..), Notice(..), empty, noticeClassToString)
+module Notice exposing
+    ( Notice(..)
+    , alert
+    , empty
+    , error
+    , info
+    , noticeToClass
+    , noticeToMessage
+    , success
+    )
 
 
 type Notice
-    = Notice String Class
-
-
-type Class
-    = NoticeAlert
-    | NoticeError
-    | NoticeInfo
-    | NoticeSuccess
+    = Alert String
+    | Error String
+    | Info String
+    | Success String
 
 
 empty : Maybe a
@@ -17,17 +22,53 @@ empty =
     Nothing
 
 
-noticeClassToString : Class -> String
-noticeClassToString class =
-    case class of
-        NoticeAlert ->
+alert : String -> Notice
+alert message =
+    Alert message
+
+
+error : String -> Notice
+error message =
+    Error message
+
+
+info : String -> Notice
+info message =
+    Info message
+
+
+success : String -> Notice
+success message =
+    Success message
+
+
+noticeToClass : Notice -> String
+noticeToClass notice =
+    case notice of
+        Alert _ ->
             "notice-alert"
 
-        NoticeError ->
+        Error _ ->
             "notice-error"
 
-        NoticeInfo ->
+        Info _ ->
             "notice-info"
 
-        NoticeSuccess ->
+        Success _ ->
             "notice-success"
+
+
+noticeToMessage : Notice -> String
+noticeToMessage notice =
+    case notice of
+        Alert message ->
+            message
+
+        Error message ->
+            message
+
+        Info message ->
+            message
+
+        Success message ->
+            message

--- a/app/elm/Notice.elm
+++ b/app/elm/Notice.elm
@@ -2,8 +2,7 @@ module Notice exposing (Class(..), Notice(..), noticeClassToString)
 
 
 type Notice
-    = EmptyNotice
-    | Notice String Class
+    = Notice String Class
 
 
 type Class

--- a/app/elm/Notice.elm
+++ b/app/elm/Notice.elm
@@ -1,6 +1,29 @@
-module Notice exposing (Notice(..))
+module Notice exposing (Class(..), Notice(..), noticeClassToString)
 
 
 type Notice
     = EmptyNotice
-    | Notice String
+    | Notice String Class
+
+
+type Class
+    = NoticeAlert
+    | NoticeError
+    | NoticeInfo
+    | NoticeSuccess
+
+
+noticeClassToString : Class -> String
+noticeClassToString class =
+    case class of
+        NoticeAlert ->
+            "notice-alert"
+
+        NoticeError ->
+            "notice-error"
+
+        NoticeInfo ->
+            "notice-info"
+
+        NoticeSuccess ->
+            "notice-success"

--- a/app/elm/Notice.elm
+++ b/app/elm/Notice.elm
@@ -7,6 +7,8 @@ module Notice exposing
     , noticeToClass
     , noticeToMessage
     , success
+    , withNotice
+    , withoutNotice
     )
 
 
@@ -72,3 +74,13 @@ noticeToMessage notice =
 
         Success message ->
             message
+
+
+withoutNotice : ( a, b ) -> ( a, b, Maybe Notice )
+withoutNotice ( a, b ) =
+    ( a, b, empty )
+
+
+withNotice : Notice -> ( a, b ) -> ( a, b, Maybe Notice )
+withNotice notice ( a, b ) =
+    ( a, b, Just notice )

--- a/app/elm/Notice.elm
+++ b/app/elm/Notice.elm
@@ -1,4 +1,4 @@
-module Notice exposing (Class(..), Notice(..), noticeClassToString)
+module Notice exposing (Class(..), Notice(..), empty, noticeClassToString)
 
 
 type Notice
@@ -10,6 +10,11 @@ type Class
     | NoticeError
     | NoticeInfo
     | NoticeSuccess
+
+
+empty : Maybe a
+empty =
+    Nothing
 
 
 noticeClassToString : Class -> String

--- a/app/elm/NoticeQueue.elm
+++ b/app/elm/NoticeQueue.elm
@@ -27,9 +27,6 @@ currentNotice (NoticeQueue queue) =
         [] ->
             Nothing
 
-        [ x ] ->
-            Just x
-
         x :: _ ->
             Just x
 

--- a/app/elm/NoticeQueue.elm
+++ b/app/elm/NoticeQueue.elm
@@ -5,8 +5,11 @@ module NoticeQueue exposing
     , empty
     , noticeTimeout
     , pop
+    , viewCurrentNotice
     )
 
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (class)
 import Notice exposing (Notice)
 import Process
 import Task
@@ -55,3 +58,27 @@ pop (NoticeQueue queue) =
 
         _ ->
             NoticeQueue []
+
+
+viewCurrentNotice : NoticeQueue -> Html a
+viewCurrentNotice queue =
+    let
+        maybeNotice =
+            currentNotice queue
+    in
+    case maybeNotice of
+        Just notice ->
+            let
+                noticeClassString =
+                    Notice.noticeToClass notice
+
+                classString =
+                    "notice " ++ noticeClassString
+
+                message =
+                    Notice.noticeToMessage notice
+            in
+            div [ class classString ] [ text message ]
+
+        _ ->
+            text ""

--- a/app/elm/NoticeQueue.elm
+++ b/app/elm/NoticeQueue.elm
@@ -30,8 +30,8 @@ currentNotice (NoticeQueue queue) =
         [] ->
             Nothing
 
-        x :: _ ->
-            Just x
+        firstNotice :: _ ->
+            Just firstNotice
 
 
 empty : NoticeQueue

--- a/app/elm/NoticeQueue.elm
+++ b/app/elm/NoticeQueue.elm
@@ -1,0 +1,35 @@
+module NoticeQueue exposing (NoticeQueue(..), append, currentNotice, empty)
+
+import Notice exposing (Notice)
+
+
+type NoticeQueue
+    = NoticeQueue (List Notice)
+
+
+append : Notice -> NoticeQueue -> NoticeQueue
+append notice (NoticeQueue queue) =
+    case notice of
+        Notice.Notice _ _ ->
+            NoticeQueue (queue ++ [ notice ])
+
+        Notice.EmptyNotice ->
+            NoticeQueue queue
+
+
+currentNotice : NoticeQueue -> Maybe Notice
+currentNotice (NoticeQueue queue) =
+    case queue of
+        [] ->
+            Nothing
+
+        [ x ] ->
+            Just x
+
+        x :: _ ->
+            Just x
+
+
+empty : NoticeQueue
+empty =
+    NoticeQueue []

--- a/app/elm/NoticeQueue.elm
+++ b/app/elm/NoticeQueue.elm
@@ -1,6 +1,15 @@
-module NoticeQueue exposing (NoticeQueue(..), append, currentNotice, empty)
+module NoticeQueue exposing
+    ( NoticeQueue(..)
+    , append
+    , currentNotice
+    , empty
+    , noticeTimeout
+    , pop
+    )
 
 import Notice exposing (Notice)
+import Process
+import Task
 
 
 type NoticeQueue
@@ -9,12 +18,7 @@ type NoticeQueue
 
 append : Notice -> NoticeQueue -> NoticeQueue
 append notice (NoticeQueue queue) =
-    case notice of
-        Notice.Notice _ _ ->
-            NoticeQueue (queue ++ [ notice ])
-
-        Notice.EmptyNotice ->
-            NoticeQueue queue
+    NoticeQueue (queue ++ [ notice ])
 
 
 currentNotice : NoticeQueue -> Maybe Notice
@@ -33,3 +37,24 @@ currentNotice (NoticeQueue queue) =
 empty : NoticeQueue
 empty =
     NoticeQueue []
+
+
+noticeDuration : Float
+noticeDuration =
+    2000
+
+
+noticeTimeout : a -> Cmd a
+noticeTimeout msg =
+    Process.sleep noticeDuration
+        |> Task.perform (always msg)
+
+
+pop : NoticeQueue -> NoticeQueue
+pop (NoticeQueue queue) =
+    case queue of
+        _ :: tail ->
+            NoticeQueue tail
+
+        _ ->
+            NoticeQueue []

--- a/app/elm/Pages/PlantDetails.elm
+++ b/app/elm/Pages/PlantDetails.elm
@@ -78,11 +78,11 @@ photoToBase64 photo =
     Task.perform PhotoConvertedToBase64 (File.toUrl photo)
 
 
-update : Msg -> Model -> ( Model, Cmd Msg, Notice )
+update : Msg -> Model -> ( Model, Cmd Msg, Maybe Notice )
 update msg model =
     case msg of
         ReceivedGetPlantResponse (Ok plant) ->
-            ( { model | plant = Just plant }, Cmd.none, EmptyNotice )
+            ( { model | plant = Just plant }, Cmd.none, Nothing )
 
         ReceivedGetPlantResponse (Err error) ->
             let
@@ -94,13 +94,13 @@ update msg model =
             in
             ( model
             , Nav.pushUrl model.key Routes.gardensPath
-            , Notice noticeMessge Notice.NoticeError
+            , Just (Notice noticeMessge Notice.NoticeError)
             )
 
         UserSelectedUploadNewPhoto ->
             ( model
             , Select.file [ "image/*" ] NewImageSelected
-            , EmptyNotice
+            , Nothing
             )
 
         NewImageSelected photo ->
@@ -108,17 +108,17 @@ update msg model =
                 Just plant ->
                     ( { model | modal = Modal.Modal <| cropperModal model }
                     , photoToBase64 photo
-                    , EmptyNotice
+                    , Nothing
                     )
 
                 Nothing ->
-                    ( model, Cmd.none, EmptyNotice )
+                    ( model, Cmd.none, Nothing )
 
         PhotoConvertedToBase64 base64Url ->
-            ( model, initJsCropper base64Url, EmptyNotice )
+            ( model, initJsCropper base64Url, Nothing )
 
         UserCroppedPhoto ->
-            ( { model | modal = ModalClosed }, Cmd.none, EmptyNotice )
+            ( { model | modal = ModalClosed }, Cmd.none, Nothing )
 
         GotCroppedPhoto photo ->
             case model.plant of
@@ -129,16 +129,16 @@ update msg model =
                     in
                     ( { model | upload = Uploading 0 }
                     , uploadPhoto model.session photo plant
-                    , EmptyNotice
+                    , Nothing
                     )
 
                 Nothing ->
-                    ( model, Cmd.none, EmptyNotice )
+                    ( model, Cmd.none, Nothing )
 
         ReceivedUploadPhotoResponse (Ok plant) ->
             ( { model | upload = Done, plant = Just plant }
             , Cmd.none
-            , Notice "Photo updated!" Notice.NoticeSuccess
+            , Just (Notice "Photo updated!" Notice.NoticeSuccess)
             )
 
         ReceivedUploadPhotoResponse (Err error) ->
@@ -148,7 +148,10 @@ update msg model =
             in
             ( model
             , Cmd.none
-            , Notice "Something went wrong. Try again later." Notice.NoticeError
+            , Just
+                (Notice "Something went wrong. Try again later."
+                    Notice.NoticeError
+                )
             )
 
         GotUploadProgress progress ->
@@ -160,16 +163,16 @@ update msg model =
                     in
                     ( { model | upload = Uploading fractionSent }
                     , Cmd.none
-                    , EmptyNotice
+                    , Nothing
                     )
 
                 Http.Receiving _ ->
-                    ( model, Cmd.none, EmptyNotice )
+                    ( model, Cmd.none, Nothing )
 
         UserClickedDeletePlant plantId ->
             ( model
             , deletePlant model.session plantId
-            , EmptyNotice
+            , Nothing
             )
 
         ReceivedDeletePlantResponse (Ok _) ->
@@ -181,26 +184,29 @@ update msg model =
                     in
                     ( model
                     , Nav.pushUrl model.key (Routes.gardenPath plant.gardenId)
-                    , Notice noticeMessge Notice.NoticeSuccess
+                    , Just (Notice noticeMessge Notice.NoticeSuccess)
                     )
 
                 ( Nothing, Success user ) ->
                     ( model
                     , Nav.pushUrl model.key (Routes.gardenPath user.defaultGardenId)
-                    , EmptyNotice
+                    , Nothing
                     )
 
                 ( _, _ ) ->
-                    ( model, Cmd.none, EmptyNotice )
+                    ( model, Cmd.none, Nothing )
 
         ReceivedDeletePlantResponse (Err _) ->
             ( model
             , Cmd.none
-            , Notice "Something went wrong. Try again later." Notice.NoticeError
+            , Just
+                (Notice "Something went wrong. Try again later."
+                    Notice.NoticeError
+                )
             )
 
         UserClickedEditPlant plantId ->
-            ( model, Cmd.none, EmptyNotice )
+            ( model, Cmd.none, Nothing )
 
 
 subscriptions : Sub Msg

--- a/app/elm/Pages/PlantDetails.elm
+++ b/app/elm/Pages/PlantDetails.elm
@@ -94,7 +94,7 @@ update msg model =
             in
             ( model
             , Nav.pushUrl model.key Routes.gardensPath
-            , Notice noticeMessge
+            , Notice noticeMessge Notice.NoticeError
             )
 
         UserSelectedUploadNewPhoto ->
@@ -138,7 +138,7 @@ update msg model =
         ReceivedUploadPhotoResponse (Ok plant) ->
             ( { model | upload = Done, plant = Just plant }
             , Cmd.none
-            , Notice "Photo updated!"
+            , Notice "Photo updated!" Notice.NoticeSuccess
             )
 
         ReceivedUploadPhotoResponse (Err error) ->
@@ -146,7 +146,10 @@ update msg model =
                 _ =
                     Debug.log "Error" error
             in
-            ( model, Cmd.none, Notice "Something went wrong. Try again later." )
+            ( model
+            , Cmd.none
+            , Notice "Something went wrong. Try again later." Notice.NoticeError
+            )
 
         GotUploadProgress progress ->
             case progress of
@@ -178,7 +181,7 @@ update msg model =
                     in
                     ( model
                     , Nav.pushUrl model.key (Routes.gardenPath plant.gardenId)
-                    , Notice noticeMessge
+                    , Notice noticeMessge Notice.NoticeSuccess
                     )
 
                 ( Nothing, Success user ) ->
@@ -191,7 +194,10 @@ update msg model =
                     ( model, Cmd.none, EmptyNotice )
 
         ReceivedDeletePlantResponse (Err _) ->
-            ( model, Cmd.none, Notice "Something went wrong. Try again later." )
+            ( model
+            , Cmd.none
+            , Notice "Something went wrong. Try again later." Notice.NoticeError
+            )
 
         UserClickedEditPlant plantId ->
             ( model, Cmd.none, EmptyNotice )

--- a/app/elm/Pages/PlantDetails.elm
+++ b/app/elm/Pages/PlantDetails.elm
@@ -82,7 +82,8 @@ update : Msg -> Model -> ( Model, Cmd Msg, Maybe Notice )
 update msg model =
     case msg of
         ReceivedGetPlantResponse (Ok plant) ->
-            ( { model | plant = Just plant }, Cmd.none, Notice.empty )
+            ( { model | plant = Just plant }, Cmd.none )
+                |> Notice.withoutNotice
 
         ReceivedGetPlantResponse (Err error) ->
             let
@@ -92,33 +93,32 @@ update msg model =
                 noticeMessge =
                     "Something went wrong. Does that plant still exist?"
             in
-            ( model
-            , Nav.pushUrl model.key Routes.gardensPath
-            , Just (Notice.error noticeMessge)
-            )
+            ( model, Nav.pushUrl model.key Routes.gardensPath )
+                |> Notice.withNotice (Notice.error noticeMessge)
 
         UserSelectedUploadNewPhoto ->
-            ( model
-            , Select.file [ "image/*" ] NewImageSelected
-            , Notice.empty
-            )
+            ( model, Select.file [ "image/*" ] NewImageSelected )
+                |> Notice.withoutNotice
 
         NewImageSelected photo ->
             case model.plant of
                 Just plant ->
                     ( { model | modal = Modal.Modal <| cropperModal model }
                     , photoToBase64 photo
-                    , Notice.empty
                     )
+                        |> Notice.withoutNotice
 
                 Nothing ->
-                    ( model, Cmd.none, Notice.empty )
+                    ( model, Cmd.none )
+                        |> Notice.withoutNotice
 
         PhotoConvertedToBase64 base64Url ->
-            ( model, initJsCropper base64Url, Notice.empty )
+            ( model, initJsCropper base64Url )
+                |> Notice.withoutNotice
 
         UserCroppedPhoto ->
-            ( { model | modal = ModalClosed }, Cmd.none, Notice.empty )
+            ( { model | modal = ModalClosed }, Cmd.none )
+                |> Notice.withoutNotice
 
         GotCroppedPhoto photo ->
             case model.plant of
@@ -127,29 +127,24 @@ update msg model =
                         updatedPlant =
                             { plant | avatarUrl = photo }
                     in
-                    ( { model | upload = Uploading 0 }
-                    , uploadPhoto model.session photo plant
-                    , Notice.empty
-                    )
+                    ( { model | upload = Uploading 0 }, uploadPhoto model.session photo plant )
+                        |> Notice.withoutNotice
 
                 Nothing ->
-                    ( model, Cmd.none, Notice.empty )
+                    ( model, Cmd.none )
+                        |> Notice.withoutNotice
 
         ReceivedUploadPhotoResponse (Ok plant) ->
-            ( { model | upload = Done, plant = Just plant }
-            , Cmd.none
-            , Just (Notice.success "Photo updated!")
-            )
+            ( { model | upload = Done, plant = Just plant }, Cmd.none )
+                |> Notice.withNotice (Notice.success "Photo Updated!")
 
         ReceivedUploadPhotoResponse (Err error) ->
             let
                 _ =
                     Debug.log "Error" error
             in
-            ( model
-            , Cmd.none
-            , Just (Notice.error "Something went wrong. Try again later.")
-            )
+            ( model, Cmd.none )
+                |> Notice.withNotice (Notice.error "Something went wrong. Try again later.")
 
         GotUploadProgress progress ->
             case progress of
@@ -158,19 +153,16 @@ update msg model =
                         fractionSent =
                             Http.fractionSent p
                     in
-                    ( { model | upload = Uploading fractionSent }
-                    , Cmd.none
-                    , Notice.empty
-                    )
+                    ( { model | upload = Uploading fractionSent }, Cmd.none )
+                        |> Notice.withoutNotice
 
                 Http.Receiving _ ->
-                    ( model, Cmd.none, Notice.empty )
+                    ( model, Cmd.none )
+                        |> Notice.withoutNotice
 
         UserClickedDeletePlant plantId ->
-            ( model
-            , deletePlant model.session plantId
-            , Notice.empty
-            )
+            ( model, deletePlant model.session plantId )
+                |> Notice.withoutNotice
 
         ReceivedDeletePlantResponse (Ok _) ->
             case ( model.plant, model.session.currentUser ) of
@@ -179,28 +171,24 @@ update msg model =
                         noticeMessge =
                             "Deleted plant: " ++ plant.name
                     in
-                    ( model
-                    , Nav.pushUrl model.key (Routes.gardenPath plant.gardenId)
-                    , Just (Notice.success noticeMessge)
-                    )
+                    ( model, Nav.pushUrl model.key (Routes.gardenPath plant.gardenId) )
+                        |> Notice.withNotice (Notice.success noticeMessge)
 
                 ( Nothing, Success user ) ->
-                    ( model
-                    , Nav.pushUrl model.key (Routes.gardenPath user.defaultGardenId)
-                    , Notice.empty
-                    )
+                    ( model, Nav.pushUrl model.key (Routes.gardenPath user.defaultGardenId) )
+                        |> Notice.withoutNotice
 
                 ( _, _ ) ->
-                    ( model, Cmd.none, Notice.empty )
+                    ( model, Cmd.none )
+                        |> Notice.withoutNotice
 
         ReceivedDeletePlantResponse (Err _) ->
-            ( model
-            , Cmd.none
-            , Just (Notice.error "Something went wrong. Try again later.")
-            )
+            ( model, Cmd.none )
+                |> Notice.withNotice (Notice.error "Something went wrong. Try again later.")
 
         UserClickedEditPlant plantId ->
-            ( model, Cmd.none, Notice.empty )
+            ( model, Cmd.none )
+                |> Notice.withoutNotice
 
 
 subscriptions : Sub Msg

--- a/app/elm/Pages/PlantDetails.elm
+++ b/app/elm/Pages/PlantDetails.elm
@@ -19,7 +19,7 @@ import Http
 import Json.Encode
 import Loadable exposing (Loadable(..))
 import Modal exposing (..)
-import Notice exposing (Notice(..))
+import Notice exposing (Notice)
 import Octicons exposing (defaultOptions)
 import Plant
 import Routes
@@ -94,7 +94,7 @@ update msg model =
             in
             ( model
             , Nav.pushUrl model.key Routes.gardensPath
-            , Just (Notice noticeMessge Notice.NoticeError)
+            , Just (Notice.error noticeMessge)
             )
 
         UserSelectedUploadNewPhoto ->
@@ -138,7 +138,7 @@ update msg model =
         ReceivedUploadPhotoResponse (Ok plant) ->
             ( { model | upload = Done, plant = Just plant }
             , Cmd.none
-            , Just (Notice "Photo updated!" Notice.NoticeSuccess)
+            , Just (Notice.success "Photo updated!")
             )
 
         ReceivedUploadPhotoResponse (Err error) ->
@@ -148,10 +148,7 @@ update msg model =
             in
             ( model
             , Cmd.none
-            , Just
-                (Notice "Something went wrong. Try again later."
-                    Notice.NoticeError
-                )
+            , Just (Notice.error "Something went wrong. Try again later.")
             )
 
         GotUploadProgress progress ->
@@ -184,7 +181,7 @@ update msg model =
                     in
                     ( model
                     , Nav.pushUrl model.key (Routes.gardenPath plant.gardenId)
-                    , Just (Notice noticeMessge Notice.NoticeSuccess)
+                    , Just (Notice.success noticeMessge)
                     )
 
                 ( Nothing, Success user ) ->
@@ -199,10 +196,7 @@ update msg model =
         ReceivedDeletePlantResponse (Err _) ->
             ( model
             , Cmd.none
-            , Just
-                (Notice "Something went wrong. Try again later."
-                    Notice.NoticeError
-                )
+            , Just (Notice.error "Something went wrong. Try again later.")
             )
 
         UserClickedEditPlant plantId ->

--- a/app/elm/Pages/PlantDetails.elm
+++ b/app/elm/Pages/PlantDetails.elm
@@ -82,7 +82,7 @@ update : Msg -> Model -> ( Model, Cmd Msg, Maybe Notice )
 update msg model =
     case msg of
         ReceivedGetPlantResponse (Ok plant) ->
-            ( { model | plant = Just plant }, Cmd.none, Nothing )
+            ( { model | plant = Just plant }, Cmd.none, Notice.empty )
 
         ReceivedGetPlantResponse (Err error) ->
             let
@@ -100,7 +100,7 @@ update msg model =
         UserSelectedUploadNewPhoto ->
             ( model
             , Select.file [ "image/*" ] NewImageSelected
-            , Nothing
+            , Notice.empty
             )
 
         NewImageSelected photo ->
@@ -108,17 +108,17 @@ update msg model =
                 Just plant ->
                     ( { model | modal = Modal.Modal <| cropperModal model }
                     , photoToBase64 photo
-                    , Nothing
+                    , Notice.empty
                     )
 
                 Nothing ->
-                    ( model, Cmd.none, Nothing )
+                    ( model, Cmd.none, Notice.empty )
 
         PhotoConvertedToBase64 base64Url ->
-            ( model, initJsCropper base64Url, Nothing )
+            ( model, initJsCropper base64Url, Notice.empty )
 
         UserCroppedPhoto ->
-            ( { model | modal = ModalClosed }, Cmd.none, Nothing )
+            ( { model | modal = ModalClosed }, Cmd.none, Notice.empty )
 
         GotCroppedPhoto photo ->
             case model.plant of
@@ -129,11 +129,11 @@ update msg model =
                     in
                     ( { model | upload = Uploading 0 }
                     , uploadPhoto model.session photo plant
-                    , Nothing
+                    , Notice.empty
                     )
 
                 Nothing ->
-                    ( model, Cmd.none, Nothing )
+                    ( model, Cmd.none, Notice.empty )
 
         ReceivedUploadPhotoResponse (Ok plant) ->
             ( { model | upload = Done, plant = Just plant }
@@ -163,16 +163,16 @@ update msg model =
                     in
                     ( { model | upload = Uploading fractionSent }
                     , Cmd.none
-                    , Nothing
+                    , Notice.empty
                     )
 
                 Http.Receiving _ ->
-                    ( model, Cmd.none, Nothing )
+                    ( model, Cmd.none, Notice.empty )
 
         UserClickedDeletePlant plantId ->
             ( model
             , deletePlant model.session plantId
-            , Nothing
+            , Notice.empty
             )
 
         ReceivedDeletePlantResponse (Ok _) ->
@@ -190,11 +190,11 @@ update msg model =
                 ( Nothing, Success user ) ->
                     ( model
                     , Nav.pushUrl model.key (Routes.gardenPath user.defaultGardenId)
-                    , Nothing
+                    , Notice.empty
                     )
 
                 ( _, _ ) ->
-                    ( model, Cmd.none, Nothing )
+                    ( model, Cmd.none, Notice.empty )
 
         ReceivedDeletePlantResponse (Err _) ->
             ( model
@@ -206,7 +206,7 @@ update msg model =
             )
 
         UserClickedEditPlant plantId ->
-            ( model, Cmd.none, Nothing )
+            ( model, Cmd.none, Notice.empty )
 
 
 subscriptions : Sub Msg

--- a/app/elm/Pages/PlantForm.elm
+++ b/app/elm/Pages/PlantForm.elm
@@ -8,7 +8,7 @@ import Html.Attributes exposing (class, id, name, selected, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Http
 import Loadable exposing (Loadable(..))
-import Notice exposing (Notice(..))
+import Notice exposing (Notice)
 import Plant
 import Routes
 import Session exposing (Session)
@@ -146,7 +146,7 @@ update msg model key =
                     in
                     ( model
                     , goBackToPlantsList key gardenId
-                    , Just (Notice noticeMessage Notice.NoticeSuccess)
+                    , Just (Notice.success noticeMessage)
                     )
 
                 ( Nothing, Success user ) ->
@@ -180,7 +180,7 @@ update msg model key =
             in
             ( model
             , goBackToPlantDetails key plant.id
-            , Just (Notice noticeMessage Notice.NoticeSuccess)
+            , Just (Notice.success noticeMessage)
             )
 
         ReceivedUpdatePlantResponse (Err error) ->
@@ -199,7 +199,7 @@ handleErrorResponse model error key =
                     in
                     ( model
                     , Nav.pushUrl key Routes.signInPath
-                    , Just (Notice noticeMessage Notice.NoticeError)
+                    , Just (Notice.error noticeMessage)
                     )
 
                 _ ->

--- a/app/elm/Pages/PlantForm.elm
+++ b/app/elm/Pages/PlantForm.elm
@@ -85,7 +85,7 @@ update : Msg -> Model -> Nav.Key -> ( Model, Cmd Msg, Maybe Notice )
 update msg model key =
     case msg of
         UserEditedField field value ->
-            ( setField field value model, Cmd.none, Nothing )
+            ( setField field value model, Cmd.none, Notice.empty )
 
         UserSubmittedForm ->
             let
@@ -102,11 +102,11 @@ update msg model key =
                         Just gardenId ->
                             ( model
                             , createNewPlant model.session gardenId validPlant
-                            , Nothing
+                            , Notice.empty
                             )
 
                         Nothing ->
-                            ( model, Cmd.none, Nothing )
+                            ( model, Cmd.none, Notice.empty )
 
                 ( Ok validatedForm, Form.Update ) ->
                     let
@@ -117,25 +117,25 @@ update msg model key =
                         Just plantId ->
                             ( model
                             , updatePlant model.session plantId validPlant
-                            , Nothing
+                            , Notice.empty
                             )
 
                         Nothing ->
-                            ( model, Cmd.none, Nothing )
+                            ( model, Cmd.none, Notice.empty )
 
                 ( Err errorList, _ ) ->
-                    ( { model | errors = errorList }, Cmd.none, Nothing )
+                    ( { model | errors = errorList }, Cmd.none, Notice.empty )
 
         UserCancelledForm ->
             case ( model.formAction, model.plantId, model.gardenId ) of
                 ( Form.Create, _, Just gardenId ) ->
-                    ( model, goBackToPlantsList key gardenId, Nothing )
+                    ( model, goBackToPlantsList key gardenId, Notice.empty )
 
                 ( Form.Update, Just plantId, Just gardenId ) ->
-                    ( model, goBackToPlantDetails key plantId, Nothing )
+                    ( model, goBackToPlantDetails key plantId, Notice.empty )
 
                 ( _, _, _ ) ->
-                    ( model, Cmd.none, Nothing )
+                    ( model, Cmd.none, Notice.empty )
 
         ReceivedCreatePlantResponse (Ok plant) ->
             case ( model.gardenId, model.session.currentUser ) of
@@ -152,11 +152,11 @@ update msg model key =
                 ( Nothing, Success user ) ->
                     ( model
                     , goBackToPlantsList key user.defaultGardenId
-                    , Nothing
+                    , Notice.empty
                     )
 
                 ( _, _ ) ->
-                    ( model, Cmd.none, Nothing )
+                    ( model, Cmd.none, Notice.empty )
 
         ReceivedCreatePlantResponse (Err error) ->
             handleErrorResponse model error key
@@ -167,7 +167,7 @@ update msg model key =
                 , gardenId = Just plant.gardenId
               }
             , Cmd.none
-            , Nothing
+            , Notice.empty
             )
 
         ReceivedGetPlantResponse (Err error) ->
@@ -205,16 +205,16 @@ handleErrorResponse model error key =
                 _ ->
                     ( { model | apiError = somethingWentWrongError }
                     , Cmd.none
-                    , Nothing
+                    , Notice.empty
                     )
 
         Http.NetworkError ->
-            ( { model | apiError = networkError }, Cmd.none, Nothing )
+            ( { model | apiError = networkError }, Cmd.none, Notice.empty )
 
         _ ->
             ( { model | apiError = somethingWentWrongError }
             , Cmd.none
-            , Nothing
+            , Notice.empty
             )
 
 

--- a/app/elm/Pages/PlantForm.elm
+++ b/app/elm/Pages/PlantForm.elm
@@ -81,11 +81,11 @@ initialPlantForm =
     { name = "", checkFrequencyScalar = "", checkFrequencyUnit = "day" }
 
 
-update : Msg -> Model -> Nav.Key -> ( Model, Cmd Msg, Notice )
+update : Msg -> Model -> Nav.Key -> ( Model, Cmd Msg, Maybe Notice )
 update msg model key =
     case msg of
         UserEditedField field value ->
-            ( setField field value model, Cmd.none, EmptyNotice )
+            ( setField field value model, Cmd.none, Nothing )
 
         UserSubmittedForm ->
             let
@@ -102,11 +102,11 @@ update msg model key =
                         Just gardenId ->
                             ( model
                             , createNewPlant model.session gardenId validPlant
-                            , EmptyNotice
+                            , Nothing
                             )
 
                         Nothing ->
-                            ( model, Cmd.none, EmptyNotice )
+                            ( model, Cmd.none, Nothing )
 
                 ( Ok validatedForm, Form.Update ) ->
                     let
@@ -117,25 +117,25 @@ update msg model key =
                         Just plantId ->
                             ( model
                             , updatePlant model.session plantId validPlant
-                            , EmptyNotice
+                            , Nothing
                             )
 
                         Nothing ->
-                            ( model, Cmd.none, EmptyNotice )
+                            ( model, Cmd.none, Nothing )
 
                 ( Err errorList, _ ) ->
-                    ( { model | errors = errorList }, Cmd.none, EmptyNotice )
+                    ( { model | errors = errorList }, Cmd.none, Nothing )
 
         UserCancelledForm ->
             case ( model.formAction, model.plantId, model.gardenId ) of
                 ( Form.Create, _, Just gardenId ) ->
-                    ( model, goBackToPlantsList key gardenId, EmptyNotice )
+                    ( model, goBackToPlantsList key gardenId, Nothing )
 
                 ( Form.Update, Just plantId, Just gardenId ) ->
-                    ( model, goBackToPlantDetails key plantId, EmptyNotice )
+                    ( model, goBackToPlantDetails key plantId, Nothing )
 
                 ( _, _, _ ) ->
-                    ( model, Cmd.none, EmptyNotice )
+                    ( model, Cmd.none, Nothing )
 
         ReceivedCreatePlantResponse (Ok plant) ->
             case ( model.gardenId, model.session.currentUser ) of
@@ -146,17 +146,17 @@ update msg model key =
                     in
                     ( model
                     , goBackToPlantsList key gardenId
-                    , Notice noticeMessage Notice.NoticeSuccess
+                    , Just (Notice noticeMessage Notice.NoticeSuccess)
                     )
 
                 ( Nothing, Success user ) ->
                     ( model
                     , goBackToPlantsList key user.defaultGardenId
-                    , EmptyNotice
+                    , Nothing
                     )
 
                 ( _, _ ) ->
-                    ( model, Cmd.none, EmptyNotice )
+                    ( model, Cmd.none, Nothing )
 
         ReceivedCreatePlantResponse (Err error) ->
             handleErrorResponse model error key
@@ -167,7 +167,7 @@ update msg model key =
                 , gardenId = Just plant.gardenId
               }
             , Cmd.none
-            , EmptyNotice
+            , Nothing
             )
 
         ReceivedGetPlantResponse (Err error) ->
@@ -180,14 +180,14 @@ update msg model key =
             in
             ( model
             , goBackToPlantDetails key plant.id
-            , Notice noticeMessage Notice.NoticeSuccess
+            , Just (Notice noticeMessage Notice.NoticeSuccess)
             )
 
         ReceivedUpdatePlantResponse (Err error) ->
             handleErrorResponse model error key
 
 
-handleErrorResponse : Model -> Http.Error -> Nav.Key -> ( Model, Cmd Msg, Notice )
+handleErrorResponse : Model -> Http.Error -> Nav.Key -> ( Model, Cmd Msg, Maybe Notice )
 handleErrorResponse model error key =
     case error of
         Http.BadStatus code ->
@@ -199,22 +199,22 @@ handleErrorResponse model error key =
                     in
                     ( model
                     , Nav.pushUrl key Routes.signInPath
-                    , Notice noticeMessage Notice.NoticeError
+                    , Just (Notice noticeMessage Notice.NoticeError)
                     )
 
                 _ ->
                     ( { model | apiError = somethingWentWrongError }
                     , Cmd.none
-                    , EmptyNotice
+                    , Nothing
                     )
 
         Http.NetworkError ->
-            ( { model | apiError = networkError }, Cmd.none, EmptyNotice )
+            ( { model | apiError = networkError }, Cmd.none, Nothing )
 
         _ ->
             ( { model | apiError = somethingWentWrongError }
             , Cmd.none
-            , EmptyNotice
+            , Nothing
             )
 
 

--- a/app/elm/Pages/PlantForm.elm
+++ b/app/elm/Pages/PlantForm.elm
@@ -146,7 +146,7 @@ update msg model key =
                     in
                     ( model
                     , goBackToPlantsList key gardenId
-                    , Notice noticeMessage
+                    , Notice noticeMessage Notice.NoticeSuccess
                     )
 
                 ( Nothing, Success user ) ->
@@ -178,7 +178,10 @@ update msg model key =
                 noticeMessage =
                     "Updated plant: " ++ plant.name
             in
-            ( model, goBackToPlantDetails key plant.id, Notice noticeMessage )
+            ( model
+            , goBackToPlantDetails key plant.id
+            , Notice noticeMessage Notice.NoticeSuccess
+            )
 
         ReceivedUpdatePlantResponse (Err error) ->
             handleErrorResponse model error key
@@ -196,7 +199,7 @@ handleErrorResponse model error key =
                     in
                     ( model
                     , Nav.pushUrl key Routes.signInPath
-                    , Notice noticeMessage
+                    , Notice noticeMessage Notice.NoticeError
                     )
 
                 _ ->

--- a/app/elm/Pages/PlantList.elm
+++ b/app/elm/Pages/PlantList.elm
@@ -102,17 +102,16 @@ update : Msg -> Model -> ( Model, Cmd Msg, Maybe Notice )
 update msg model =
     case msg of
         NewPlants (Ok newPlants) ->
-            ( { model | plants = newPlants, loading = Success }
-            , Cmd.none
-            , Notice.empty
-            )
+            ( { model | plants = newPlants, loading = Success }, Cmd.none )
+                |> Notice.withoutNotice
 
         NewPlants (Err error) ->
             let
                 _ =
                     Debug.log "Whoops!" error
             in
-            ( { model | loading = Failed }, Cmd.none, Notice.empty )
+            ( { model | loading = Failed }, Cmd.none )
+                |> Notice.withoutNotice
 
         UserOpenedCheckInModal plant ->
             let
@@ -125,6 +124,7 @@ update msg model =
             ( model, Cmd.none )
                 |> updateForm newCheckInForm
                 |> updateModal checkInModal
+                |> Notice.withoutNotice
 
         CheckboxSelected eventType ->
             let
@@ -134,6 +134,7 @@ update msg model =
             ( model, Cmd.none )
                 |> updateForm newCheckInForm
                 |> updateModal checkInModal
+                |> Notice.withoutNotice
 
         UserClickedFileSelect ->
             ( model, Select.file [ "image/*" ] NewImageSelected, Notice.empty )
@@ -152,11 +153,13 @@ update msg model =
             ( model, Cmd.none )
                 |> updateForm newCheckInForm
                 |> updateModal checkInModal
+                |> Notice.withoutNotice
 
         UserClosedModal ->
             ( model, Cmd.none )
                 |> updateForm initialCheckInForm
                 |> closeModal
+                |> Notice.withoutNotice
 
         UserSubmittedCheckIn ->
             ( model, submitCheckIn model.session model.checkInForm, Notice.empty )
@@ -176,11 +179,12 @@ update msg model =
                         |> updatePlantWateredAt plant checkIn.createdAt
                         |> updateForm initialCheckInForm
                         |> closeModal
-                        |> modifyNotice (Notice.success noticeMessage)
+                        |> Notice.withNotice (Notice.success noticeMessage)
 
                 Nothing ->
                     ( model, Cmd.none )
                         |> closeModal
+                        |> Notice.withoutNotice
 
         ReceivedPlantCheckInResponse (Err error) ->
             ( model
@@ -199,6 +203,7 @@ update msg model =
             ( model, Cmd.none )
                 |> updateForm updatedForm
                 |> updateModal checkInModal
+                |> Notice.withoutNotice
 
         UserRemovedImageFromModal index ->
             let
@@ -214,6 +219,7 @@ update msg model =
             ( model, Cmd.none )
                 |> updateForm updatedForm
                 |> updateModal checkInModal
+                |> Notice.withoutNotice
 
 
 photoToBase64 : File.File -> Cmd Msg
@@ -246,22 +252,14 @@ updateForm form ( model, cmd ) =
 updateModal :
     (CheckInForm -> Html Msg)
     -> ( Model, Cmd Msg )
-    -> ( Model, Cmd Msg, Maybe Notice )
+    -> ( Model, Cmd Msg )
 updateModal modal ( model, cmd ) =
-    ( { model | modal = Modal <| modal model.checkInForm }, cmd, Notice.empty )
+    ( { model | modal = Modal <| modal model.checkInForm }, cmd )
 
 
-closeModal : ( Model, Cmd Msg ) -> ( Model, Cmd Msg, Maybe Notice )
+closeModal : ( Model, Cmd Msg ) -> ( Model, Cmd Msg )
 closeModal ( model, cmd ) =
-    ( { model | modal = ModalClosed }, cmd, Notice.empty )
-
-
-modifyNotice :
-    Notice
-    -> ( Model, Cmd Msg, Maybe Notice )
-    -> ( Model, Cmd Msg, Maybe Notice )
-modifyNotice newNotice ( model, msg, _ ) =
-    ( model, msg, Just newNotice )
+    ( { model | modal = ModalClosed }, cmd )
 
 
 findPlantById : Int -> List Plant.Plant -> Maybe Plant.Plant

--- a/app/elm/Pages/PlantList.elm
+++ b/app/elm/Pages/PlantList.elm
@@ -104,7 +104,7 @@ update msg model =
         NewPlants (Ok newPlants) ->
             ( { model | plants = newPlants, loading = Success }
             , Cmd.none
-            , Nothing
+            , Notice.empty
             )
 
         NewPlants (Err error) ->
@@ -112,7 +112,7 @@ update msg model =
                 _ =
                     Debug.log "Whoops!" error
             in
-            ( { model | loading = Failed }, Cmd.none, Nothing )
+            ( { model | loading = Failed }, Cmd.none, Notice.empty )
 
         UserOpenedCheckInModal plant ->
             let
@@ -136,10 +136,10 @@ update msg model =
                 |> updateModal checkInModal
 
         UserClickedFileSelect ->
-            ( model, Select.file [ "image/*" ] NewImageSelected, Nothing )
+            ( model, Select.file [ "image/*" ] NewImageSelected, Notice.empty )
 
         NewImageSelected file ->
-            ( model, photoToBase64 file, Nothing )
+            ( model, photoToBase64 file, Notice.empty )
 
         UserTypedCheckInNotes notes ->
             let
@@ -159,7 +159,7 @@ update msg model =
                 |> closeModal
 
         UserSubmittedCheckIn ->
-            ( model, submitCheckIn model.session model.checkInForm, Nothing )
+            ( model, submitCheckIn model.session model.checkInForm, Notice.empty )
 
         ReceivedPlantCheckInResponse (Ok checkIn) ->
             let
@@ -251,12 +251,12 @@ updateModal :
     -> ( Model, Cmd Msg )
     -> ( Model, Cmd Msg, Maybe Notice )
 updateModal modal ( model, cmd ) =
-    ( { model | modal = Modal <| modal model.checkInForm }, cmd, Nothing )
+    ( { model | modal = Modal <| modal model.checkInForm }, cmd, Notice.empty )
 
 
 closeModal : ( Model, Cmd Msg ) -> ( Model, Cmd Msg, Maybe Notice )
 closeModal ( model, cmd ) =
-    ( { model | modal = ModalClosed }, cmd, Nothing )
+    ( { model | modal = ModalClosed }, cmd, Notice.empty )
 
 
 modifyNotice :

--- a/app/elm/Pages/PlantList.elm
+++ b/app/elm/Pages/PlantList.elm
@@ -176,7 +176,7 @@ update msg model =
                         |> updatePlantWateredAt plant checkIn.createdAt
                         |> updateForm initialCheckInForm
                         |> closeModal
-                        |> modifyNotice noticeMessage Notice.NoticeSuccess
+                        |> modifyNotice (Notice.success noticeMessage)
 
                 Nothing ->
                     ( model, Cmd.none )
@@ -185,10 +185,7 @@ update msg model =
         ReceivedPlantCheckInResponse (Err error) ->
             ( model
             , Cmd.none
-            , Just
-                (Notice "Something went wrong. Try again later"
-                    Notice.NoticeError
-                )
+            , Just (Notice.error "Something went wrong. Try again later")
             )
 
         PhotoConvertedToBase64 base64Photo ->
@@ -260,12 +257,11 @@ closeModal ( model, cmd ) =
 
 
 modifyNotice :
-    String
-    -> Notice.Class
+    Notice
     -> ( Model, Cmd Msg, Maybe Notice )
     -> ( Model, Cmd Msg, Maybe Notice )
-modifyNotice newNotice noticeClass ( model, msg, _ ) =
-    ( model, msg, Just (Notice newNotice noticeClass) )
+modifyNotice newNotice ( model, msg, _ ) =
+    ( model, msg, Just newNotice )
 
 
 findPlantById : Int -> List Plant.Plant -> Maybe Plant.Plant

--- a/app/elm/Pages/PlantList.elm
+++ b/app/elm/Pages/PlantList.elm
@@ -98,13 +98,13 @@ initialCheckInForm =
     CheckInForm False False "" [] 0 ""
 
 
-update : Msg -> Model -> ( Model, Cmd Msg, Notice )
+update : Msg -> Model -> ( Model, Cmd Msg, Maybe Notice )
 update msg model =
     case msg of
         NewPlants (Ok newPlants) ->
             ( { model | plants = newPlants, loading = Success }
             , Cmd.none
-            , EmptyNotice
+            , Nothing
             )
 
         NewPlants (Err error) ->
@@ -112,7 +112,7 @@ update msg model =
                 _ =
                     Debug.log "Whoops!" error
             in
-            ( { model | loading = Failed }, Cmd.none, EmptyNotice )
+            ( { model | loading = Failed }, Cmd.none, Nothing )
 
         UserOpenedCheckInModal plant ->
             let
@@ -136,10 +136,10 @@ update msg model =
                 |> updateModal checkInModal
 
         UserClickedFileSelect ->
-            ( model, Select.file [ "image/*" ] NewImageSelected, EmptyNotice )
+            ( model, Select.file [ "image/*" ] NewImageSelected, Nothing )
 
         NewImageSelected file ->
-            ( model, photoToBase64 file, EmptyNotice )
+            ( model, photoToBase64 file, Nothing )
 
         UserTypedCheckInNotes notes ->
             let
@@ -159,7 +159,7 @@ update msg model =
                 |> closeModal
 
         UserSubmittedCheckIn ->
-            ( model, submitCheckIn model.session model.checkInForm, EmptyNotice )
+            ( model, submitCheckIn model.session model.checkInForm, Nothing )
 
         ReceivedPlantCheckInResponse (Ok checkIn) ->
             let
@@ -185,7 +185,10 @@ update msg model =
         ReceivedPlantCheckInResponse (Err error) ->
             ( model
             , Cmd.none
-            , Notice "Something went wrong. Try again later" Notice.NoticeError
+            , Just
+                (Notice "Something went wrong. Try again later"
+                    Notice.NoticeError
+                )
             )
 
         PhotoConvertedToBase64 base64Photo ->
@@ -246,23 +249,23 @@ updateForm form ( model, cmd ) =
 updateModal :
     (CheckInForm -> Html Msg)
     -> ( Model, Cmd Msg )
-    -> ( Model, Cmd Msg, Notice )
+    -> ( Model, Cmd Msg, Maybe Notice )
 updateModal modal ( model, cmd ) =
-    ( { model | modal = Modal <| modal model.checkInForm }, cmd, EmptyNotice )
+    ( { model | modal = Modal <| modal model.checkInForm }, cmd, Nothing )
 
 
-closeModal : ( Model, Cmd Msg ) -> ( Model, Cmd Msg, Notice )
+closeModal : ( Model, Cmd Msg ) -> ( Model, Cmd Msg, Maybe Notice )
 closeModal ( model, cmd ) =
-    ( { model | modal = ModalClosed }, cmd, EmptyNotice )
+    ( { model | modal = ModalClosed }, cmd, Nothing )
 
 
 modifyNotice :
     String
     -> Notice.Class
-    -> ( Model, Cmd Msg, Notice )
-    -> ( Model, Cmd Msg, Notice )
+    -> ( Model, Cmd Msg, Maybe Notice )
+    -> ( Model, Cmd Msg, Maybe Notice )
 modifyNotice newNotice noticeClass ( model, msg, _ ) =
-    ( model, msg, Notice newNotice noticeClass )
+    ( model, msg, Just (Notice newNotice noticeClass) )
 
 
 findPlantById : Int -> List Plant.Plant -> Maybe Plant.Plant

--- a/app/elm/Pages/PlantList.elm
+++ b/app/elm/Pages/PlantList.elm
@@ -176,14 +176,17 @@ update msg model =
                         |> updatePlantWateredAt plant checkIn.createdAt
                         |> updateForm initialCheckInForm
                         |> closeModal
-                        |> modifyNotice noticeMessage
+                        |> modifyNotice noticeMessage Notice.NoticeSuccess
 
                 Nothing ->
                     ( model, Cmd.none )
                         |> closeModal
 
         ReceivedPlantCheckInResponse (Err error) ->
-            ( model, Cmd.none, Notice "Something went wrong. Try again later" )
+            ( model
+            , Cmd.none
+            , Notice "Something went wrong. Try again later" Notice.NoticeError
+            )
 
         PhotoConvertedToBase64 base64Photo ->
             let
@@ -253,9 +256,13 @@ closeModal ( model, cmd ) =
     ( { model | modal = ModalClosed }, cmd, EmptyNotice )
 
 
-modifyNotice : String -> ( Model, Cmd Msg, Notice ) -> ( Model, Cmd Msg, Notice )
-modifyNotice newNotice ( model, msg, _ ) =
-    ( model, msg, Notice newNotice )
+modifyNotice :
+    String
+    -> Notice.Class
+    -> ( Model, Cmd Msg, Notice )
+    -> ( Model, Cmd Msg, Notice )
+modifyNotice newNotice noticeClass ( model, msg, _ ) =
+    ( model, msg, Notice newNotice noticeClass )
 
 
 findPlantById : Int -> List Plant.Plant -> Maybe Plant.Plant


### PR DESCRIPTION
This PR introduces functionality to give users feedback on their actions using a flash message.

Two new types are introduced: `Notice` and `NoticeQueue`

The `Notice` type represents the message and kind of message (alert, warning, etc.) being presented to the user

The `NoticeQueue` type represents a list of `Notice` in case many messages need to be presented to the user. Each time a `Notice` is added to the queue, a timeout is started. After the timeout, the message on the front of the queue is removed so the next queue, if any, can be shown.